### PR TITLE
fix: prevent open redirect vulnerability in OIDC callback

### DIFF
--- a/secure-oidc-login.php
+++ b/secure-oidc-login.php
@@ -468,10 +468,9 @@ class Secure_OIDC_Login {
 		do_action( 'wp_login', $user->user_login, $user );
 
 		// Redirect to requested page or admin dashboard
-		$redirect_url = admin_url();
-		if ( ! empty( $_GET['redirect_to'] ) ) {
-			$redirect_url = esc_url_raw( $_GET['redirect_to'] );
-		}
+		// Use wp_validate_redirect() to prevent open redirect vulnerabilities
+		$requested_redirect = ! empty( $_GET['redirect_to'] ) ? $_GET['redirect_to'] : '';
+		$redirect_url       = wp_validate_redirect( $requested_redirect, admin_url() );
 
 		wp_safe_redirect( $redirect_url );
 		exit;


### PR DESCRIPTION
Replace esc_url_raw() with wp_validate_redirect() in the OIDC callback
handler to prevent open redirect attacks. This ensures redirects are
validated against the current domain with a safe fallback to admin_url().

Fixes #2 - addresses CWE-601 (URL Redirection to Untrusted Site)