### PR TITLE
fix: sanitize redirect_to parameter before validation

### DIFF
--- a/secure-oidc-login.php
+++ b/secure-oidc-login.php
@@ -486,7 +486,8 @@ class Secure_OIDC_Login {
 
 		// Redirect to requested page or admin dashboard
 		// Use wp_validate_redirect() to prevent open redirect vulnerabilities
-		$requested_redirect = ! empty( $_GET['redirect_to'] ) ? $_GET['redirect_to'] : '';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Redirect URL from OAuth callback
+		$requested_redirect = ! empty( $_GET['redirect_to'] ) ? esc_url_raw( wp_unslash( $_GET['redirect_to'] ) ) : '';
 		$redirect_url       = wp_validate_redirect( $requested_redirect, admin_url() );
 
 		wp_safe_redirect( $redirect_url );


### PR DESCRIPTION
Sanitize the $_GET['redirect_to'] parameter with esc_url_raw() and wp_unslash() before passing it to wp_validate_redirect(). While wp_validate_redirect() provides protection against open redirects, it's a WordPress security best practice to sanitize all user input before use.

This prevents potential security issues where unsanitized user input could be used in URL validation.

Fixes #9