### PR TITLE
Validate IdP response content-types before decoding JSON

### DIFF
--- a/includes/class-oidc-admin.php
+++ b/includes/class-oidc-admin.php
@@ -760,15 +760,17 @@ class OIDC_Admin {
 			wp_send_json_error( $response->get_error_message() );
 		}
 
-		$status_code  = wp_remote_retrieve_response_code( $response );
+		$status_code = wp_remote_retrieve_response_code( $response );
 
 		if ( $status_code !== 200 ) {
 			wp_send_json_error( __( 'Failed to fetch discovery document.', 'secure-oidc-login' ) );
 		}
 
-		$body          = wp_remote_retrieve_body( $response );
-		$content_type  = wp_remote_retrieve_header( $response, 'content-type' );
-		$content_type  = false === $content_type ? '' : (string) $content_type;
+		$body         = wp_remote_retrieve_body( $response );
+		$content_type = wp_remote_retrieve_header( $response, 'content-type' );
+		if ( is_array( $content_type ) ) {
+			$content_type = $content_type[0] ?? '';
+		}
 		if ( stripos( $content_type, 'application/json' ) === false ) {
 			wp_send_json_error( __( 'Discovery response was not JSON. Please verify the identity provider configuration.', 'secure-oidc-login' ) );
 		}

--- a/includes/class-oidc-client.php
+++ b/includes/class-oidc-client.php
@@ -152,10 +152,12 @@ class OIDC_Client {
 			);
 		}
 
-		$status_code   = wp_remote_retrieve_response_code( $response );
-		$body          = wp_remote_retrieve_body( $response );
-		$content_type  = wp_remote_retrieve_header( $response, 'content-type' );
-		$content_type  = false === $content_type ? '' : (string) $content_type;
+		$status_code  = wp_remote_retrieve_response_code( $response );
+		$body         = wp_remote_retrieve_body( $response );
+		$content_type = wp_remote_retrieve_header( $response, 'content-type' );
+		if ( is_array( $content_type ) ) {
+			$content_type = $content_type[0] ?? '';
+		}
 
 		if ( stripos( $content_type, 'application/json' ) === false ) {
 			return $this->handle_error(
@@ -509,7 +511,9 @@ class OIDC_Client {
 		$status_code  = wp_remote_retrieve_response_code( $response );
 		$body         = wp_remote_retrieve_body( $response );
 		$content_type = wp_remote_retrieve_header( $response, 'content-type' );
-		$content_type = false === $content_type ? '' : (string) $content_type;
+		if ( is_array( $content_type ) ) {
+			$content_type = $content_type[0] ?? '';
+		}
 
 		if ( stripos( $content_type, 'application/json' ) === false ) {
 			return $this->handle_error(
@@ -590,10 +594,12 @@ class OIDC_Client {
 			);
 		}
 
-		$status_code   = wp_remote_retrieve_response_code( $response );
-		$body          = wp_remote_retrieve_body( $response );
-		$content_type  = wp_remote_retrieve_header( $response, 'content-type' );
-		$content_type  = false === $content_type ? '' : (string) $content_type;
+		$status_code  = wp_remote_retrieve_response_code( $response );
+		$body         = wp_remote_retrieve_body( $response );
+		$content_type = wp_remote_retrieve_header( $response, 'content-type' );
+		if ( is_array( $content_type ) ) {
+			$content_type = $content_type[0] ?? '';
+		}
 
 		if ( stripos( $content_type, 'application/json' ) === false ) {
 			return $this->handle_error(
@@ -653,7 +659,9 @@ class OIDC_Client {
 		$status_code  = wp_remote_retrieve_response_code( $response );
 		$body         = wp_remote_retrieve_body( $response );
 		$content_type = wp_remote_retrieve_header( $response, 'content-type' );
-		$content_type = false === $content_type ? '' : (string) $content_type;
+		if ( is_array( $content_type ) ) {
+			$content_type = $content_type[0] ?? '';
+		}
 
 		if ( stripos( $content_type, 'application/json' ) === false ) {
 			return new WP_Error(


### PR DESCRIPTION
## Summary
- ensure discovery requests validate JSON content type before decoding
- guard all token and userinfo exchanges against non-JSON responses
- return descriptive admin and user-facing errors when the IdP sends unexpected formats

## Testing
- [ ] Automated tests
- [x] Manual verification of discovery request with mocked IdP errors
