### PR TITLE
fix: use JWT alg-appropriate hash for at_hash and c_hash validation

### DIFF
--- a/includes/class-oidc-client.php
+++ b/includes/class-oidc-client.php
@@ -84,6 +84,34 @@ class OIDC_Client {
 	);
 
 	/**
+	 * Get the hash algorithm and left-half byte count for a JWT signing algorithm.
+	 *
+	 * Per OIDC Core Section 3.3.2.11, the hash used for at_hash and c_hash must
+	 * correspond to the alg header parameter of the ID token's JOSE header:
+	 *   - *256 algorithms → SHA-256, left 128 bits (16 bytes)
+	 *   - *384 algorithms → SHA-384, left 192 bits (24 bytes)
+	 *   - *512 algorithms → SHA-512, left 256 bits (32 bytes)
+	 *
+	 * @param string $alg The JWT signing algorithm (e.g., 'RS256', 'ES384', 'PS512', 'EdDSA').
+	 * @return array{0: string, 1: int} Array of [hash_algorithm, left_half_bytes].
+	 */
+	private static function get_hash_params_for_alg( string $alg ): array {
+		if ( preg_match( '/(\d{3})$/', $alg, $matches ) ) {
+			$bits = (int) $matches[1];
+		} elseif ( 'EdDSA' === $alg ) {
+			$bits = 512; // Ed25519 uses SHA-512 internally
+		} else {
+			$bits = 256; // Safe default
+		}
+
+		return match ( $bits ) {
+			384 => array( 'sha384', 24 ),
+			512 => array( 'sha512', 32 ),
+			default => array( 'sha256', 16 ),
+		};
+	}
+
+	/**
 	 * Initialize the client with plugin settings.
 	 */
 	public function __construct() {
@@ -297,6 +325,10 @@ class OIDC_Client {
 			return $claims;
 		}
 
+		// Extract and remove the internal JWT algorithm marker set by decode_and_verify_jwt.
+		$jwt_alg = $claims['__jwt_alg'] ?? 'RS256';
+		unset( $claims['__jwt_alg'] );
+
 		// Verify required 'sub' claim is present (OIDC Core spec 2.2)
 		if ( empty( $claims['sub'] ) ) {
 			return new WP_Error( 'oidc_error', __( 'Missing required sub claim in ID token.', 'secure-oidc-login' ) );
@@ -348,8 +380,9 @@ class OIDC_Client {
 		// not match, preventing the token from being accepted. This binds the ID token to the
 		// specific authorization code used in this exchange.
 		if ( null !== $auth_code && isset( $claims['c_hash'] ) ) {
-			// Per spec: c_hash is left-most half of SHA-256 hash, base64url encoded
-			$computed_hash = rtrim( strtr( base64_encode( substr( hash( 'sha256', $auth_code, true ), 0, 16 ) ), '+/', '-_' ), '=' );
+			// Per spec: c_hash is base64url of left-most half of hash, using the alg's hash function.
+			list( $hash_alg, $hash_len ) = self::get_hash_params_for_alg( $jwt_alg );
+			$computed_hash = rtrim( strtr( base64_encode( substr( hash( $hash_alg, $auth_code, true ), 0, $hash_len ) ), '+/', '-_' ), '=' );
 			if ( $claims['c_hash'] !== $computed_hash ) {
 				return new WP_Error( 'invalid_c_hash', 'ID token c_hash does not match authorization code' );
 			}
@@ -360,7 +393,8 @@ class OIDC_Client {
 		// preventing token substitution attacks where an attacker pairs a legitimate
 		// ID token with a different access token to get UserInfo for another user.
 		if ( null !== $access_token && isset( $claims['at_hash'] ) ) {
-			$computed_hash = rtrim( strtr( base64_encode( substr( hash( 'sha256', $access_token, true ), 0, 16 ) ), '+/', '-_' ), '=' );
+			list( $hash_alg, $hash_len ) = self::get_hash_params_for_alg( $jwt_alg );
+			$computed_hash = rtrim( strtr( base64_encode( substr( hash( $hash_alg, $access_token, true ), 0, $hash_len ) ), '+/', '-_' ), '=' );
 			if ( $claims['at_hash'] !== $computed_hash ) {
 				return new WP_Error( 'invalid_at_hash', 'ID token at_hash does not match access token' );
 			}
@@ -522,7 +556,9 @@ class OIDC_Client {
 			$decoded = JWT::decode( $jwt, $keys );
 
 			// Convert stdClass to array for consistency with existing code
-			return json_decode( json_encode( $decoded ), true );
+			$claims          = json_decode( json_encode( $decoded ), true );
+			$claims['__jwt_alg'] = $alg;
+			return $claims;
 
 		} catch ( \Firebase\JWT\SignatureInvalidException $e ) {
 			// Signature verification failed - could be due to IdP key rotation

--- a/includes/class-oidc-client.php
+++ b/includes/class-oidc-client.php
@@ -382,7 +382,7 @@ class OIDC_Client {
 		if ( null !== $auth_code && isset( $claims['c_hash'] ) ) {
 			// Per spec: c_hash is base64url of left-most half of hash, using the alg's hash function.
 			list( $hash_alg, $hash_len ) = self::get_hash_params_for_alg( $jwt_alg );
-			$computed_hash = rtrim( strtr( base64_encode( substr( hash( $hash_alg, $auth_code, true ), 0, $hash_len ) ), '+/', '-_' ), '=' );
+			$computed_hash               = rtrim( strtr( base64_encode( substr( hash( $hash_alg, $auth_code, true ), 0, $hash_len ) ), '+/', '-_' ), '=' );
 			if ( $claims['c_hash'] !== $computed_hash ) {
 				return new WP_Error( 'invalid_c_hash', 'ID token c_hash does not match authorization code' );
 			}
@@ -394,7 +394,7 @@ class OIDC_Client {
 		// ID token with a different access token to get UserInfo for another user.
 		if ( null !== $access_token && isset( $claims['at_hash'] ) ) {
 			list( $hash_alg, $hash_len ) = self::get_hash_params_for_alg( $jwt_alg );
-			$computed_hash = rtrim( strtr( base64_encode( substr( hash( $hash_alg, $access_token, true ), 0, $hash_len ) ), '+/', '-_' ), '=' );
+			$computed_hash               = rtrim( strtr( base64_encode( substr( hash( $hash_alg, $access_token, true ), 0, $hash_len ) ), '+/', '-_' ), '=' );
 			if ( $claims['at_hash'] !== $computed_hash ) {
 				return new WP_Error( 'invalid_at_hash', 'ID token at_hash does not match access token' );
 			}
@@ -556,7 +556,7 @@ class OIDC_Client {
 			$decoded = JWT::decode( $jwt, $keys );
 
 			// Convert stdClass to array for consistency with existing code
-			$claims          = json_decode( json_encode( $decoded ), true );
+			$claims              = json_decode( json_encode( $decoded ), true );
 			$claims['__jwt_alg'] = $alg;
 			return $claims;
 

--- a/tests/Unit/Client/OIDCClientTest.php
+++ b/tests/Unit/Client/OIDCClientTest.php
@@ -1437,6 +1437,146 @@ class OIDCClientTest extends OIDCTestCase
     }
 
     /**
+     * Test get_hash_params_for_alg returns correct params for all supported algorithms.
+     */
+    public function testGetHashParamsForAlg(): void
+    {
+        $reflection = new \ReflectionMethod(OIDC_Client::class, 'get_hash_params_for_alg');
+        $reflection->setAccessible(true);
+
+        // *256 algorithms → SHA-256, 16 bytes
+        foreach (['RS256', 'ES256', 'PS256'] as $alg) {
+            $result = $reflection->invoke(null, $alg);
+            $this->assertSame(['sha256', 16], $result, "Algorithm $alg should use SHA-256");
+        }
+
+        // *384 algorithms → SHA-384, 24 bytes
+        foreach (['RS384', 'ES384', 'PS384'] as $alg) {
+            $result = $reflection->invoke(null, $alg);
+            $this->assertSame(['sha384', 24], $result, "Algorithm $alg should use SHA-384");
+        }
+
+        // *512 algorithms → SHA-512, 32 bytes
+        foreach (['RS512', 'ES512', 'PS512'] as $alg) {
+            $result = $reflection->invoke(null, $alg);
+            $this->assertSame(['sha512', 32], $result, "Algorithm $alg should use SHA-512");
+        }
+
+        // EdDSA → SHA-512, 32 bytes
+        $result = $reflection->invoke(null, 'EdDSA');
+        $this->assertSame(['sha512', 32], $result, 'EdDSA should use SHA-512');
+    }
+
+    /**
+     * Test validate_id_token accepts valid at_hash with RS384 (SHA-384).
+     */
+    public function testValidateIdTokenAcceptsValidAtHashWithRS384(): void
+    {
+        $accessToken = 'test-access-token-value';
+        $atHash = rtrim(strtr(base64_encode(substr(hash('sha384', $accessToken, true), 0, 24)), '+/', '-_'), '=');
+
+        $client = $this->createClientWithStubbedJwt([
+            '__jwt_alg' => 'RS384',
+            'sub' => 'user-123',
+            'iss' => 'https://idp.example.com',
+            'aud' => 'test-client-id',
+            'at_hash' => $atHash,
+        ]);
+
+        $result = $client->validate_id_token('fake.jwt.token', null, null, $accessToken);
+
+        $this->assertIsArray($result);
+        $this->assertSame('user-123', $result['sub']);
+    }
+
+    /**
+     * Test validate_id_token accepts valid at_hash with RS512 (SHA-512).
+     */
+    public function testValidateIdTokenAcceptsValidAtHashWithRS512(): void
+    {
+        $accessToken = 'test-access-token-value';
+        $atHash = rtrim(strtr(base64_encode(substr(hash('sha512', $accessToken, true), 0, 32)), '+/', '-_'), '=');
+
+        $client = $this->createClientWithStubbedJwt([
+            '__jwt_alg' => 'RS512',
+            'sub' => 'user-123',
+            'iss' => 'https://idp.example.com',
+            'aud' => 'test-client-id',
+            'at_hash' => $atHash,
+        ]);
+
+        $result = $client->validate_id_token('fake.jwt.token', null, null, $accessToken);
+
+        $this->assertIsArray($result);
+        $this->assertSame('user-123', $result['sub']);
+    }
+
+    /**
+     * Test validate_id_token rejects SHA-256 at_hash when algorithm is RS384.
+     *
+     * If the JWT is signed with RS384 but at_hash was computed with SHA-256,
+     * validation should fail because the hash algorithm doesn't match.
+     */
+    public function testValidateIdTokenRejectsSha256AtHashWithRS384(): void
+    {
+        $accessToken = 'test-access-token-value';
+        // Compute at_hash with wrong algorithm (SHA-256 instead of SHA-384)
+        $wrongAtHash = rtrim(strtr(base64_encode(substr(hash('sha256', $accessToken, true), 0, 16)), '+/', '-_'), '=');
+
+        $client = $this->createClientWithStubbedJwt([
+            '__jwt_alg' => 'RS384',
+            'sub' => 'user-123',
+            'iss' => 'https://idp.example.com',
+            'aud' => 'test-client-id',
+            'at_hash' => $wrongAtHash,
+        ]);
+
+        $result = $client->validate_id_token('fake.jwt.token', null, null, $accessToken);
+
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame('invalid_at_hash', $result->get_error_code());
+    }
+
+    /**
+     * Test validate_id_token accepts valid c_hash with RS384 (SHA-384).
+     */
+    public function testValidateIdTokenAcceptsValidCHashWithRS384(): void
+    {
+        $authCode = 'test-authorization-code';
+        $cHash = rtrim(strtr(base64_encode(substr(hash('sha384', $authCode, true), 0, 24)), '+/', '-_'), '=');
+
+        $client = $this->createClientWithStubbedJwt([
+            '__jwt_alg' => 'RS384',
+            'sub' => 'user-123',
+            'iss' => 'https://idp.example.com',
+            'aud' => 'test-client-id',
+            'c_hash' => $cHash,
+        ]);
+
+        $result = $client->validate_id_token('fake.jwt.token', null, $authCode);
+
+        $this->assertIsArray($result);
+        $this->assertSame('user-123', $result['sub']);
+    }
+
+    /**
+     * Test validate_id_token does not leak __jwt_alg into returned claims.
+     */
+    public function testValidateIdTokenStripsJwtAlgFromClaims(): void
+    {
+        $client = $this->createClientWithStubbedJwt([
+            'sub' => 'user-123',
+            'iss' => 'https://idp.example.com',
+            'aud' => 'test-client-id',
+        ]);
+
+        $result = $client->validate_id_token('fake.jwt.token');
+
+        $this->assertIsArray($result);
+        $this->assertArrayNotHasKey('__jwt_alg', $result);
+    }
+
+    /**
      * Test that nonce validation is case-sensitive.
      */
     public function testNonceValidationIsCaseSensitive(): void
@@ -2219,7 +2359,7 @@ class OIDCClientTest extends OIDCTestCase
 
             protected function decode_and_verify_jwt(string $jwt, bool $retry = true): array|\WP_Error
             {
-                return $this->stubbedClaims;
+                return array_merge(['__jwt_alg' => 'RS256'], $this->stubbedClaims);
             }
         };
     }


### PR DESCRIPTION
Per OIDC Core Section 3.3.2.11, the hash algorithm for at_hash/c_hash
must correspond to the JWT's alg header (*256→SHA-256, *384→SHA-384,
*512→SHA-512). Previously SHA-256 was hardcoded, which would incorrectly
reject tokens signed with non-256 algorithms that include these claims.

Adds get_hash_params_for_alg() helper and passes the JWT alg from
decode_and_verify_jwt to validate_id_token via an internal __jwt_alg key.
