### PR TITLE
Return WP_Error for empty input in encrypt() and decrypt_if_needed()

### DIFF
--- a/includes/class-oidc-token-crypto.php
+++ b/includes/class-oidc-token-crypto.php
@@ -63,7 +63,10 @@ class OIDC_Token_Crypto {
 	 */
 	public static function encrypt( string $plaintext ): string|WP_Error {
 		if ( '' === $plaintext ) {
-			return '';
+			return new WP_Error(
+				'oidc_encrypt_empty_input',
+				__( 'Cannot encrypt an empty string.', 'secure-oidc-login' )
+			);
 		}
 
 		if ( ! self::is_supported() ) {
@@ -118,7 +121,10 @@ class OIDC_Token_Crypto {
 	 */
 	public static function decrypt_if_needed( string $value ): string|WP_Error {
 		if ( '' === $value ) {
-			return '';
+			return new WP_Error(
+				'oidc_decrypt_empty_input',
+				__( 'Cannot decrypt an empty string.', 'secure-oidc-login' )
+			);
 		}
 
 		// Route to appropriate decryption method based on version prefix

--- a/tests/Unit/Crypto/OIDCTokenCryptoTest.php
+++ b/tests/Unit/Crypto/OIDCTokenCryptoTest.php
@@ -42,13 +42,14 @@ class OIDCTokenCryptoTest extends OIDCTestCase
     }
 
     /**
-     * Test encrypt returns empty string for empty input.
+     * Test encrypt returns WP_Error for empty input.
      */
-    public function testEncryptReturnsEmptyStringForEmptyInput(): void
+    public function testEncryptReturnsWpErrorForEmptyInput(): void
     {
         $result = OIDC_Token_Crypto::encrypt('');
 
-        $this->assertSame('', $result);
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame('oidc_encrypt_empty_input', $result->get_error_code());
     }
 
     /**
@@ -78,13 +79,14 @@ class OIDCTokenCryptoTest extends OIDCTestCase
     }
 
     /**
-     * Test decrypt_if_needed returns empty string for empty input.
+     * Test decrypt_if_needed returns WP_Error for empty input.
      */
-    public function testDecryptIfNeededReturnsEmptyStringForEmptyInput(): void
+    public function testDecryptIfNeededReturnsWpErrorForEmptyInput(): void
     {
         $result = OIDC_Token_Crypto::decrypt_if_needed('');
 
-        $this->assertSame('', $result);
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame('oidc_decrypt_empty_input', $result->get_error_code());
     }
 
     /**


### PR DESCRIPTION
Empty strings silently passed through encryption/decryption, which could
mask bugs where an empty token is stored without error. Now returns
WP_Error with descriptive error codes instead.

https://claude.ai/code/session_016bbSSZZucuJWJu8tco67wi