### PR TITLE
refactor: remove legacy OpenSSL v1 encryption backward compatibility

### DIFF
--- a/includes/class-oidc-token-crypto.php
+++ b/includes/class-oidc-token-crypto.php
@@ -22,26 +22,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * - Compatibility: Pure-PHP fallback ensures availability on all WordPress installations
  * - Standard: IETF RFC 8439, used in TLS 1.3 and modern security protocols
  *
- * BACKWARD COMPATIBILITY: Supports decrypting legacy OpenSSL AES-256-GCM tokens (v1).
- * New tokens are encrypted with Sodium ChaCha20-Poly1305 (v2).
+ * All new tokens are encrypted with Sodium ChaCha20-Poly1305 (v2).
  */
 class OIDC_Token_Crypto {
 	// Current version (Sodium ChaCha20-Poly1305-IETF)
 	const PREFIX_V2       = 'enc:v2:';
 	const NONCE_LENGTH_V2 = 12; // SODIUM_CRYPTO_AEAD_CHACHA20POLY1305_IETF_NPUBBYTES
 	const KEY_LENGTH_V2   = 32; // SODIUM_CRYPTO_AEAD_CHACHA20POLY1305_IETF_KEYBYTES
-
-	// Legacy version (OpenSSL AES-256-GCM) - kept for backward compatibility
-	const PREFIX_V1     = 'enc:v1:';
-	const CIPHER_V1     = 'aes-256-gcm';
-	const IV_LENGTH_V1  = 12;
-	const TAG_LENGTH_V1 = 16;
-
-	// Deprecated constants for backward compatibility
-	const PREFIX     = self::PREFIX_V1;
-	const CIPHER     = self::CIPHER_V1;
-	const IV_LENGTH  = self::IV_LENGTH_V1;
-	const TAG_LENGTH = self::TAG_LENGTH_V1;
 
 	/**
 	 * Check if the environment supports required Sodium functions.
@@ -61,20 +48,6 @@ class OIDC_Token_Crypto {
 		// Either via native PHP extension or sodium_compat pure-PHP fallback
 		return function_exists( 'sodium_crypto_aead_chacha20poly1305_ietf_encrypt' )
 			&& function_exists( 'sodium_crypto_aead_chacha20poly1305_ietf_decrypt' );
-	}
-
-	/**
-	 * Check if OpenSSL v1 decryption is available (for backward compatibility).
-	 *
-	 * @return bool
-	 */
-	private static function is_openssl_supported(): bool {
-		if ( ! function_exists( 'openssl_encrypt' ) || ! function_exists( 'openssl_decrypt' ) ) {
-			return false;
-		}
-
-		$ciphers = openssl_get_cipher_methods( true );
-		return in_array( self::CIPHER_V1, $ciphers, true );
 	}
 
 	/**
@@ -131,11 +104,9 @@ class OIDC_Token_Crypto {
 	/**
 	 * Decrypt a stored token if it is encrypted.
 	 *
-	 * SECURITY: Handles backward compatibility with multiple encryption versions:
-	 * - v2 (current): Sodium ChaCha20-Poly1305-IETF
-	 * - v1 (legacy): OpenSSL AES-256-GCM
+	 * SECURITY: Only v2 (Sodium ChaCha20-Poly1305-IETF) tokens are supported.
 	 *
-	 * SECURITY: Plaintext tokens are NO LONGER SUPPORTED as of v0.5.0.
+	 * SECURITY: Plaintext and legacy v1 tokens are NO LONGER SUPPORTED.
 	 * Users with legacy plaintext tokens must re-authenticate to generate
 	 * properly encrypted tokens. This change prevents database leak attacks
 	 * from exposing sensitive session tokens.
@@ -153,17 +124,15 @@ class OIDC_Token_Crypto {
 		// Route to appropriate decryption method based on version prefix
 		if ( strpos( $value, self::PREFIX_V2 ) === 0 ) {
 			return self::decrypt_v2_sodium( $value );
-		} elseif ( strpos( $value, self::PREFIX_V1 ) === 0 ) {
-			return self::decrypt_v1_openssl( $value );
-		} else {
-			// SECURITY: Plaintext tokens are no longer supported as of v0.5.0
-			// Users must re-authenticate to generate properly encrypted tokens
-			self::log_error( 'Plaintext token rejected - user must re-authenticate for encrypted token storage.' );
-			return new WP_Error(
-				'oidc_plaintext_token_rejected',
-				__( 'Your session has expired. Please log in again.', 'secure-oidc-login' )
-			);
 		}
+
+		// SECURITY: Only v2 tokens are supported. Legacy v1 and plaintext tokens
+		// require re-authentication to generate properly encrypted tokens.
+		self::log_error( 'Unsupported token format rejected - user must re-authenticate for encrypted token storage.' );
+		return new WP_Error(
+			'oidc_plaintext_token_rejected',
+			__( 'Your session has expired. Please log in again.', 'secure-oidc-login' )
+		);
 	}
 
 	/**
@@ -222,55 +191,6 @@ class OIDC_Token_Crypto {
 	}
 
 	/**
-	 * Decrypt a v1 token encrypted with OpenSSL AES-256-GCM (legacy).
-	 *
-	 * @param string $value Encrypted token with v1 prefix.
-	 * @return string|WP_Error Decrypted token or error.
-	 */
-	private static function decrypt_v1_openssl( string $value ): string|WP_Error {
-		if ( ! self::is_openssl_supported() ) {
-			return new WP_Error(
-				'oidc_encryption_unavailable',
-				__( 'OpenSSL AES-256-GCM is not available on this server for legacy token decryption.', 'secure-oidc-login' )
-			);
-		}
-
-		// Remove prefix and decode base64 payload
-		$payload = substr( $value, strlen( self::PREFIX_V1 ) );
-		$decoded = base64_decode( $payload, true );
-
-		if ( false === $decoded ) {
-			return new WP_Error( 'oidc_decryption_failed', __( 'Invalid encrypted token payload.', 'secure-oidc-login' ) );
-		}
-
-		// Validate minimum length: IV (12 bytes) + tag (16 bytes) = 28 bytes minimum
-		if ( strlen( $decoded ) < ( self::IV_LENGTH_V1 + self::TAG_LENGTH_V1 ) ) {
-			return new WP_Error( 'oidc_decryption_failed', __( 'Encrypted token payload is too short.', 'secure-oidc-login' ) );
-		}
-
-		// Extract components from concatenated binary data
-		// Byte structure: [0-11: IV][12-27: tag][28+: ciphertext]
-		$iv         = substr( $decoded, 0, self::IV_LENGTH_V1 );
-		$tag        = substr( $decoded, self::IV_LENGTH_V1, self::TAG_LENGTH_V1 );
-		$ciphertext = substr( $decoded, self::IV_LENGTH_V1 + self::TAG_LENGTH_V1 );
-
-		try {
-			$key       = self::get_key();
-			$plaintext = openssl_decrypt( $ciphertext, self::CIPHER_V1, $key, OPENSSL_RAW_DATA, $iv, $tag );
-
-			if ( false === $plaintext ) {
-				return new WP_Error( 'oidc_decryption_failed', __( 'Failed to decrypt token.', 'secure-oidc-login' ) );
-			}
-
-			return $plaintext;
-
-		} catch ( Exception $e ) {
-			self::log_error( 'Token decryption (v1) failed: ' . $e->getMessage() );
-			return new WP_Error( 'oidc_decryption_failed', __( 'Failed to decrypt token.', 'secure-oidc-login' ) );
-		}
-	}
-
-	/**
 	 * Log an internal error message (without exposing sensitive data).
 	 *
 	 * @param string $message Message to log.
@@ -286,10 +206,6 @@ class OIDC_Token_Crypto {
 	 * from wp-config.php (AUTH_KEY, SECURE_AUTH_KEY, etc.) with the provided string.
 	 * This creates a site-specific encryption key that is not stored in the database.
 	 *
-	 * The same key is used for both Sodium ChaCha20-Poly1305 (v2) and OpenSSL
-	 * AES-256-GCM (v1) to ensure tokens encrypted with v1 can still be decrypted
-	 * after the migration to v2.
-	 *
 	 * SECURITY: If WordPress salts are rotated (e.g., after a security incident),
 	 * all previously encrypted tokens will become undecryptable. This is intentional
 	 * behavior - salt rotation should invalidate all sessions. Refer to WordPress
@@ -300,7 +216,7 @@ class OIDC_Token_Crypto {
 	private static function get_key(): string {
 		// wp_salt() creates a hash from WordPress auth salts + our string
 		$salt = wp_salt( 'secure_oidc_token' );
-		// Hash to exactly 256 bits (32 bytes) - suitable for both ChaCha20 and AES-256
+		// Hash to exactly 256 bits (32 bytes) for ChaCha20-Poly1305
 		return hash( 'sha256', $salt, true );
 	}
 }

--- a/tests/Unit/Crypto/OIDCTokenCryptoTest.php
+++ b/tests/Unit/Crypto/OIDCTokenCryptoTest.php
@@ -229,135 +229,19 @@ class OIDCTokenCryptoTest extends OIDCTestCase
         $this->assertSame(12, OIDC_Token_Crypto::NONCE_LENGTH_V2);
         $this->assertSame(32, OIDC_Token_Crypto::KEY_LENGTH_V2);
 
-        // Legacy constants
-        $this->assertSame('enc:v1:', OIDC_Token_Crypto::PREFIX_V1);
-        $this->assertSame('aes-256-gcm', OIDC_Token_Crypto::CIPHER_V1);
     }
 
     /**
-     * Test v1 legacy token handling when OpenSSL is available.
+     * Test decrypt_if_needed rejects legacy v1 tokens.
      */
-    public function testV1LegacyTokenDecryptionIfSupported(): void
+    public function testDecryptIfNeededRejectsV1Tokens(): void
     {
-        // Skip if OpenSSL AES-256-GCM is not available
-        if (!function_exists('openssl_encrypt') || !in_array('aes-256-gcm', openssl_get_cipher_methods(true))) {
-            $this->markTestSkipped('OpenSSL AES-256-GCM not available');
-        }
-
-        // Create a v1 encrypted token manually to test backward compatibility
-        // This simulates tokens encrypted before the Sodium migration
-        $key = hash('sha256', 'test-salt-value-for-unit-testing', true);
-        $plaintext = 'legacy-token-value';
-        $iv = random_bytes(12);
-        $tag = '';
-
-        $ciphertext = openssl_encrypt($plaintext, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $iv, $tag);
-        $v1Token = 'enc:v1:' . base64_encode($iv . $tag . $ciphertext);
+        $v1Token = 'enc:v1:' . base64_encode('some-encrypted-data');
 
         $result = OIDC_Token_Crypto::decrypt_if_needed($v1Token);
 
-        $this->assertSame($plaintext, $result);
-    }
-
-    /**
-     * Test decrypt_if_needed returns error for invalid v1 base64 payload.
-     */
-    public function testDecryptIfNeededReturnsErrorForInvalidV1Base64(): void
-    {
-        $invalid = 'enc:v1:not-valid-base64!!!';
-
-        $result = OIDC_Token_Crypto::decrypt_if_needed($invalid);
-
         $this->assertInstanceOf(WP_Error::class, $result);
-        $this->assertSame('oidc_decryption_failed', $result->get_error_code());
-    }
-
-    /**
-     * Test decrypt_if_needed returns error for truncated v1 payload.
-     */
-    public function testDecryptIfNeededReturnsErrorForTruncatedV1Payload(): void
-    {
-        // Create a payload shorter than required minimum (IV 12 + tag 16 = 28 bytes)
-        $shortPayload = 'enc:v1:' . base64_encode('tooshort');
-
-        $result = OIDC_Token_Crypto::decrypt_if_needed($shortPayload);
-
-        $this->assertInstanceOf(WP_Error::class, $result);
-        $this->assertSame('oidc_decryption_failed', $result->get_error_code());
-    }
-
-    /**
-     * Test decrypt_if_needed returns error for tampered v1 payload.
-     */
-    public function testDecryptIfNeededReturnsErrorForTamperedV1Payload(): void
-    {
-        // Skip if OpenSSL AES-256-GCM is not available
-        if (!function_exists('openssl_encrypt') || !in_array('aes-256-gcm', openssl_get_cipher_methods(true))) {
-            $this->markTestSkipped('OpenSSL AES-256-GCM not available');
-        }
-
-        // Create valid v1 token
-        $key = hash('sha256', 'test-salt-value-for-unit-testing', true);
-        $plaintext = 'test-token';
-        $iv = random_bytes(12);
-        $tag = '';
-
-        $ciphertext = openssl_encrypt($plaintext, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $iv, $tag);
-        $v1Token = 'enc:v1:' . base64_encode($iv . $tag . $ciphertext);
-
-        // Tamper with the payload
-        $tampered = $v1Token . 'tampered';
-
-        $result = OIDC_Token_Crypto::decrypt_if_needed($tampered);
-
-        $this->assertInstanceOf(WP_Error::class, $result);
-    }
-
-    /**
-     * Test v1 round-trip with complex content for backward compatibility.
-     */
-    public function testV1RoundTripWithComplexContent(): void
-    {
-        // Skip if OpenSSL AES-256-GCM is not available
-        if (!function_exists('openssl_encrypt') || !in_array('aes-256-gcm', openssl_get_cipher_methods(true))) {
-            $this->markTestSkipped('OpenSSL AES-256-GCM not available');
-        }
-
-        // Simulate complex JWT-like token
-        $plaintext = 'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIiwibmFtZSI6IkpvaG4ifQ.signature';
-        $key = hash('sha256', 'test-salt-value-for-unit-testing', true);
-        $iv = random_bytes(12);
-        $tag = '';
-
-        $ciphertext = openssl_encrypt($plaintext, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $iv, $tag);
-        $v1Token = 'enc:v1:' . base64_encode($iv . $tag . $ciphertext);
-
-        $result = OIDC_Token_Crypto::decrypt_if_needed($v1Token);
-
-        $this->assertSame($plaintext, $result);
-    }
-
-    /**
-     * Test v1 decryption with special characters.
-     */
-    public function testV1DecryptionWithSpecialCharacters(): void
-    {
-        // Skip if OpenSSL AES-256-GCM is not available
-        if (!function_exists('openssl_encrypt') || !in_array('aes-256-gcm', openssl_get_cipher_methods(true))) {
-            $this->markTestSkipped('OpenSSL AES-256-GCM not available');
-        }
-
-        $plaintext = "test\n\t\rwith special @#$%";
-        $key = hash('sha256', 'test-salt-value-for-unit-testing', true);
-        $iv = random_bytes(12);
-        $tag = '';
-
-        $ciphertext = openssl_encrypt($plaintext, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $iv, $tag);
-        $v1Token = 'enc:v1:' . base64_encode($iv . $tag . $ciphertext);
-
-        $result = OIDC_Token_Crypto::decrypt_if_needed($v1Token);
-
-        $this->assertSame($plaintext, $result);
+        $this->assertSame('oidc_plaintext_token_rejected', $result->get_error_code());
     }
 
     /**
@@ -511,83 +395,6 @@ class OIDCTokenCryptoTest extends OIDCTestCase
     }
 
     /**
-     * Test v1 decryption with minimal payload (edge case).
-     */
-    public function testV1DecryptionWithMinimalPayload(): void
-    {
-        // Skip if OpenSSL AES-256-GCM is not available
-        if (!function_exists('openssl_encrypt') || !in_array('aes-256-gcm', openssl_get_cipher_methods(true))) {
-            $this->markTestSkipped('OpenSSL AES-256-GCM not available');
-        }
-
-        $plaintext = 'x'; // Single character
-        $key = hash('sha256', 'test-salt-value-for-unit-testing', true);
-        $iv = random_bytes(12);
-        $tag = '';
-
-        $ciphertext = openssl_encrypt($plaintext, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $iv, $tag);
-        $v1Token = 'enc:v1:' . base64_encode($iv . $tag . $ciphertext);
-
-        $result = OIDC_Token_Crypto::decrypt_if_needed($v1Token);
-
-        $this->assertSame($plaintext, $result);
-    }
-
-    /**
-     * Test v1 decryption with corrupted tag fails.
-     */
-    public function testV1DecryptionWithCorruptedTagFails(): void
-    {
-        // Skip if OpenSSL AES-256-GCM is not available
-        if (!function_exists('openssl_encrypt') || !in_array('aes-256-gcm', openssl_get_cipher_methods(true))) {
-            $this->markTestSkipped('OpenSSL AES-256-GCM not available');
-        }
-
-        $plaintext = 'test-token';
-        $key = hash('sha256', 'test-salt-value-for-unit-testing', true);
-        $iv = random_bytes(12);
-        $tag = '';
-
-        $ciphertext = openssl_encrypt($plaintext, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $iv, $tag);
-
-        // Corrupt the tag by flipping bits
-        $corruptedTag = $tag ^ str_repeat("\xFF", strlen($tag));
-        $v1Token = 'enc:v1:' . base64_encode($iv . $corruptedTag . $ciphertext);
-
-        $result = OIDC_Token_Crypto::decrypt_if_needed($v1Token);
-
-        $this->assertInstanceOf(WP_Error::class, $result);
-        $this->assertSame('oidc_decryption_failed', $result->get_error_code());
-    }
-
-    /**
-     * Test v1 decryption with corrupted ciphertext fails.
-     */
-    public function testV1DecryptionWithCorruptedCiphertextFails(): void
-    {
-        // Skip if OpenSSL AES-256-GCM is not available
-        if (!function_exists('openssl_encrypt') || !in_array('aes-256-gcm', openssl_get_cipher_methods(true))) {
-            $this->markTestSkipped('OpenSSL AES-256-GCM not available');
-        }
-
-        $plaintext = 'test-token';
-        $key = hash('sha256', 'test-salt-value-for-unit-testing', true);
-        $iv = random_bytes(12);
-        $tag = '';
-
-        $ciphertext = openssl_encrypt($plaintext, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $iv, $tag);
-
-        // Corrupt the ciphertext
-        $corruptedCiphertext = 'corrupted' . substr($ciphertext, 9);
-        $v1Token = 'enc:v1:' . base64_encode($iv . $tag . $corruptedCiphertext);
-
-        $result = OIDC_Token_Crypto::decrypt_if_needed($v1Token);
-
-        $this->assertInstanceOf(WP_Error::class, $result);
-        $this->assertSame('oidc_decryption_failed', $result->get_error_code());
-    }
-
-    /**
      * Test v2 decryption with corrupted nonce doesn't return original plaintext.
      *
      * When the nonce is corrupted, AEAD authentication should fail.
@@ -678,22 +485,6 @@ class OIDCTokenCryptoTest extends OIDCTestCase
     }
 
     /**
-     * Test v1 token with exact minimum length (IV + tag only, no ciphertext).
-     */
-    public function testV1TokenWithExactMinimumLength(): void
-    {
-        // 12 bytes IV + 16 bytes tag = 28 bytes minimum
-        $minPayload = str_repeat('x', 28);
-        $v1Token = 'enc:v1:' . base64_encode($minPayload);
-
-        $result = OIDC_Token_Crypto::decrypt_if_needed($v1Token);
-
-        // Should fail decryption (invalid content) but not fail length check
-        $this->assertInstanceOf(WP_Error::class, $result);
-        $this->assertSame('oidc_decryption_failed', $result->get_error_code());
-    }
-
-    /**
      * Test v2 token with exact minimum length (nonce + tag only).
      *
      * A 28-byte payload (12 nonce + 16 tag with empty ciphertext) passes the
@@ -716,21 +507,6 @@ class OIDCTokenCryptoTest extends OIDCTestCase
             // it should at least be empty or garbage, not a valid token
             $this->assertTrue(strlen($result) === 0 || $result === false);
         }
-    }
-
-    /**
-     * Test v1 payload with only IV (too short).
-     */
-    public function testV1PayloadWithOnlyIvTooShort(): void
-    {
-        // Only 12 bytes (IV only, no tag)
-        $shortPayload = str_repeat('x', 12);
-        $v1Token = 'enc:v1:' . base64_encode($shortPayload);
-
-        $result = OIDC_Token_Crypto::decrypt_if_needed($v1Token);
-
-        $this->assertInstanceOf(WP_Error::class, $result);
-        $this->assertSame('oidc_decryption_failed', $result->get_error_code());
     }
 
     /**
@@ -760,37 +536,4 @@ class OIDCTokenCryptoTest extends OIDCTestCase
         $this->assertStringContainsString('log in again', $result->get_error_message());
     }
 
-    /**
-     * Test v1 and v2 tokens produce different encrypted outputs for same input.
-     */
-    public function testV1AndV2ProduceDifferentOutputsForSameInput(): void
-    {
-        // Skip if OpenSSL AES-256-GCM is not available
-        if (!function_exists('openssl_encrypt') || !in_array('aes-256-gcm', openssl_get_cipher_methods(true))) {
-            $this->markTestSkipped('OpenSSL AES-256-GCM not available');
-        }
-
-        $plaintext = 'test-token';
-
-        // Create v1 token
-        $key = hash('sha256', 'test-salt-value-for-unit-testing', true);
-        $iv = random_bytes(12);
-        $tag = '';
-        $ciphertext = openssl_encrypt($plaintext, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $iv, $tag);
-        $v1Token = 'enc:v1:' . base64_encode($iv . $tag . $ciphertext);
-
-        // Create v2 token
-        $v2Token = OIDC_Token_Crypto::encrypt($plaintext);
-
-        // Different prefixes
-        $this->assertStringStartsWith('enc:v1:', $v1Token);
-        $this->assertStringStartsWith('enc:v2:', $v2Token);
-
-        // Both should decrypt to same plaintext
-        $decrypted1 = OIDC_Token_Crypto::decrypt_if_needed($v1Token);
-        $decrypted2 = OIDC_Token_Crypto::decrypt_if_needed($v2Token);
-
-        $this->assertSame($plaintext, $decrypted1);
-        $this->assertSame($plaintext, $decrypted2);
-    }
 }


### PR DESCRIPTION
## Summary

- Remove OpenSSL AES-256-GCM (v1) decryption fallback from `OIDC_Token_Crypto`. All tokens should have been re-encrypted under v2 (Sodium ChaCha20-Poly1305) by now; legacy v1 tokens now trigger re-authentication like plaintext tokens do. The v2 prefix is retained for future encryption evolution.
- Improve inline documentation in `class-oidc-client.php` and `class-oidc-user-info.php`.

## Changes

- `includes/class-oidc-token-crypto.php` — drop v1 decryption path and related helpers
- `tests/Unit/Crypto/OIDCTokenCryptoTest.php` — drop v1 test coverage
- `includes/class-oidc-client.php`, `includes/class-oidc-user-info.php` — documentation improvements

## Test plan

- [x] `composer test` — unit tests pass with v1 cases removed
- [ ] Manual: existing v2-encrypted sessions continue to work
- [x] Manual: sessions with any lingering v1 tokens are gracefully invalidated and prompt re-auth
