### PR TITLE
Add wp_unslash() to sanitize $_GET parameters in OIDC callback

### DIFF
--- a/secure-oidc-login.php
+++ b/secure-oidc-login.php
@@ -528,7 +528,7 @@ class Secure_OIDC_Login {
 			return;
 		}
 
-		$state        = sanitize_text_field( $_GET['state'] );
+		$state        = sanitize_text_field( wp_unslash( $_GET['state'] ) );
 		$stored_state = get_transient( 'oidc_state_' . $state );
 
 		if ( ! $stored_state ) {
@@ -542,9 +542,9 @@ class Secure_OIDC_Login {
 		if ( ! empty( $_GET['error'] ) ) {
 			// Keep if-then for nested condition clarity
 			if ( ! empty( $_GET['error_description'] ) ) {
-				$error_description = sanitize_text_field( $_GET['error_description'] );
+				$error_description = sanitize_text_field( wp_unslash( $_GET['error_description'] ) );
 			} else {
-				$error_description = sanitize_text_field( $_GET['error'] );
+				$error_description = sanitize_text_field( wp_unslash( $_GET['error'] ) );
 			}
 			$this->handle_error( $error_description );
 			return;
@@ -555,7 +555,7 @@ class Secure_OIDC_Login {
 			return;
 		}
 
-		$code          = sanitize_text_field( $_GET['code'] );
+		$code          = sanitize_text_field( wp_unslash( $_GET['code'] ) );
 		$code_verifier = get_transient( 'oidc_code_verifier_' . $state );
 		delete_transient( 'oidc_code_verifier_' . $state );
 


### PR DESCRIPTION
## Summary
This PR adds `wp_unslash()` calls to properly handle escaped superglobal values before sanitization in the OIDC callback handler.

## Key Changes
- Wrapped `$_GET['state']` with `wp_unslash()` before `sanitize_text_field()`
- Wrapped `$_GET['error_description']` with `wp_unslash()` before `sanitize_text_field()`
- Wrapped `$_GET['error']` with `wp_unslash()` before `sanitize_text_field()`
- Wrapped `$_GET['code']` with `wp_unslash()` before `sanitize_text_field()`

## Implementation Details
WordPress automatically escapes superglobal values like `$_GET` for security. When these values are accessed, they contain escaped characters (e.g., backslashes). The `wp_unslash()` function removes this escaping before the values are passed to sanitization functions, ensuring that the sanitization functions receive the actual user input and can properly validate and clean it.

This change follows WordPress security best practices for handling superglobal data in the callback handler.

https://claude.ai/code/session_01AV4S92FNxWUgwanktmaKVK