### PR TITLE
Prevent client_secret leakage in admin form and preserve on empty submission

### DIFF
--- a/includes/class-oidc-admin.php
+++ b/includes/class-oidc-admin.php
@@ -1116,8 +1116,8 @@ class OIDC_Admin {
 		// state backups. Render an empty input with a placeholder when a value
 		// is already stored; sanitize_settings() preserves the existing value
 		// when the submitted field is empty.
-		$displayed_value   = $is_credential_field ? '' : $value;
-		$placeholder_attr  = '';
+		$displayed_value  = $is_credential_field ? '' : $value;
+		$placeholder_attr = '';
 		if ( $is_credential_field && '' !== $value ) {
 			$placeholder_attr = ' placeholder="' . esc_attr( '••••••••••••' ) . '"';
 		}

--- a/includes/class-oidc-admin.php
+++ b/includes/class-oidc-admin.php
@@ -687,6 +687,16 @@ class OIDC_Admin {
 					$sanitized[ $field ] = $existing_settings[ $field ] ?? '';
 					continue;
 				}
+
+				// The admin form never renders the stored client_secret into the
+				// DOM (see render_password_field). Treat an empty submission as
+				// "keep the existing value" so saving the form doesn't wipe the
+				// stored secret. Admins clear the secret explicitly via the
+				// "Remove Stored Credentials" control.
+				if ( 'client_secret' === $field && '' === $value && ! empty( $existing_settings[ $field ] ) ) {
+					$sanitized[ $field ] = $existing_settings[ $field ];
+					continue;
+				}
 			}
 
 			// Validate length if max length is defined for this field
@@ -1087,6 +1097,9 @@ class OIDC_Admin {
 			} else {
 				// Unsafe mode is enabled - show security warning
 				$description_message = __( 'Warning: Storing client secrets in the database is a security risk. Use environment variables in production.', 'secure-oidc-login' );
+				if ( '' !== $value ) {
+					$description_message .= ' ' . __( 'A value is already saved; leave this field blank to keep it, or enter a new value to replace it.', 'secure-oidc-login' );
+				}
 			}
 		}
 
@@ -1096,13 +1109,27 @@ class OIDC_Admin {
 			$autocomplete_attr = ' autocomplete="new-password"';
 		}
 
+		// SECURITY: Never render a stored credential value into the DOM. The
+		// admin page is only visible to users with manage_options, but echoing
+		// the secret into an <input value="..."> still leaks it to browser
+		// extensions, DevTools, page caches, autofill storage, and session-
+		// state backups. Render an empty input with a placeholder when a value
+		// is already stored; sanitize_settings() preserves the existing value
+		// when the submitted field is empty.
+		$displayed_value   = $is_credential_field ? '' : $value;
+		$placeholder_attr  = '';
+		if ( $is_credential_field && '' !== $value ) {
+			$placeholder_attr = ' placeholder="' . esc_attr( '••••••••••••' ) . '"';
+		}
+
 		printf(
-			'<input type="password" name="secure_oidc_login_settings[%s]" value="%s" class="regular-text"%s%s%s>',
+			'<input type="password" name="secure_oidc_login_settings[%s]" value="%s" class="regular-text"%s%s%s%s>',
 			esc_attr( $field ),
-			esc_attr( $value ),
+			esc_attr( $displayed_value ),
 			$maxlength,
 			$is_disabled ? ' disabled' : '',
-			$autocomplete_attr
+			$autocomplete_attr,
+			$placeholder_attr
 		);
 
 		if ( $is_env_overridden ) {

--- a/tests/Unit/Admin/OIDCAdminTest.php
+++ b/tests/Unit/Admin/OIDCAdminTest.php
@@ -595,6 +595,122 @@ class OIDCAdminTest extends OIDCTestCase
     }
 
     /**
+     * Test render_password_field never emits the stored client_secret value into the DOM.
+     */
+    public function testRenderPasswordFieldDoesNotLeakStoredClientSecret(): void
+    {
+        Functions\when('get_option')->justReturn(['client_secret' => 'super-secret-value']);
+        Functions\when('esc_attr')->alias(fn($v) => $v);
+        Functions\when('esc_html')->alias(fn($v) => $v);
+        Functions\when('esc_html__')->alias(fn($v, $d) => $v);
+        Functions\when('__')->alias(fn($v, $d) => $v);
+
+        putenv('SECURE_OIDC_ALLOW_UNSAFE=true');
+        putenv('SECURE_OIDC_CLIENT_SECRET');
+
+        ob_start();
+        $this->admin->render_password_field(['field' => 'client_secret']);
+        $output = ob_get_clean();
+
+        // The stored value must never appear in the rendered input.
+        $this->assertStringNotContainsString('super-secret-value', $output);
+        $this->assertStringContainsString('value=""', $output);
+        // A placeholder signals that a value is already stored.
+        $this->assertStringContainsString('placeholder="', $output);
+
+        putenv('SECURE_OIDC_ALLOW_UNSAFE');
+    }
+
+    /**
+     * Test render_password_field omits placeholder when no client_secret is stored.
+     */
+    public function testRenderPasswordFieldOmitsPlaceholderWhenNoStoredSecret(): void
+    {
+        Functions\when('get_option')->justReturn([]);
+        Functions\when('esc_attr')->alias(fn($v) => $v);
+        Functions\when('esc_html')->alias(fn($v) => $v);
+        Functions\when('esc_html__')->alias(fn($v, $d) => $v);
+        Functions\when('__')->alias(fn($v, $d) => $v);
+
+        putenv('SECURE_OIDC_ALLOW_UNSAFE=true');
+        putenv('SECURE_OIDC_CLIENT_SECRET');
+
+        ob_start();
+        $this->admin->render_password_field(['field' => 'client_secret']);
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('value=""', $output);
+        $this->assertStringNotContainsString('placeholder="', $output);
+
+        putenv('SECURE_OIDC_ALLOW_UNSAFE');
+    }
+
+    /**
+     * Test sanitize_settings preserves existing client_secret when submitted value is empty.
+     *
+     * The admin form intentionally renders an empty input for client_secret so
+     * the stored value is never echoed into the DOM. Saving the form without
+     * re-entering the secret must therefore keep the existing value instead
+     * of wiping it.
+     */
+    public function testSanitizeSettingsPreservesClientSecretOnEmptySubmission(): void
+    {
+        Functions\when('get_option')->justReturn([
+            'client_id' => 'existing-client-id',
+            'client_secret' => 'existing-client-secret',
+        ]);
+        Functions\when('current_user_can')->justReturn(true);
+        Functions\when('wp_verify_nonce')->justReturn(true);
+
+        putenv('SECURE_OIDC_ALLOW_UNSAFE=true');
+        putenv('SECURE_OIDC_CLIENT_ID');
+        putenv('SECURE_OIDC_CLIENT_SECRET');
+
+        $_POST['_wpnonce'] = 'valid-nonce';
+
+        $input = [
+            'client_id' => 'existing-client-id',
+            'client_secret' => '',
+        ];
+
+        $result = $this->admin->sanitize_settings($input);
+
+        $this->assertSame('existing-client-secret', $result['client_secret']);
+
+        putenv('SECURE_OIDC_ALLOW_UNSAFE');
+    }
+
+    /**
+     * Test sanitize_settings replaces client_secret when a new non-empty value is submitted.
+     */
+    public function testSanitizeSettingsReplacesClientSecretOnNonEmptySubmission(): void
+    {
+        Functions\when('get_option')->justReturn([
+            'client_id' => 'existing-client-id',
+            'client_secret' => 'existing-client-secret',
+        ]);
+        Functions\when('current_user_can')->justReturn(true);
+        Functions\when('wp_verify_nonce')->justReturn(true);
+
+        putenv('SECURE_OIDC_ALLOW_UNSAFE=true');
+        putenv('SECURE_OIDC_CLIENT_ID');
+        putenv('SECURE_OIDC_CLIENT_SECRET');
+
+        $_POST['_wpnonce'] = 'valid-nonce';
+
+        $input = [
+            'client_id' => 'existing-client-id',
+            'client_secret' => 'rotated-client-secret',
+        ];
+
+        $result = $this->admin->sanitize_settings($input);
+
+        $this->assertSame('rotated-client-secret', $result['client_secret']);
+
+        putenv('SECURE_OIDC_ALLOW_UNSAFE');
+    }
+
+    /**
      * Test sanitize_settings preserves existing credentials when unsafe mode disabled.
      */
     public function testSanitizeSettingsPreservesExistingCredentialsWithoutUnsafeMode(): void


### PR DESCRIPTION
## Summary
This PR enhances the security of client secret handling in the OIDC admin settings form by preventing the stored secret from being rendered into the DOM and implementing intelligent preservation of existing secrets when the form is saved without re-entering the value.

## Key Changes

- **Prevent DOM leakage of stored client_secret**: Modified `render_password_field()` to always render an empty value for credential fields, even when a value is stored. A placeholder indicator (••••••••••••) is shown instead to signal that a value exists.

- **Preserve existing secret on empty submission**: Updated `sanitize_settings()` to detect when the client_secret field is submitted empty and a value already exists, preserving the existing secret instead of wiping it. This accommodates the intentional empty rendering in the form.

- **Improved user guidance**: Added a contextual message to the password field description when unsafe mode is enabled and a value is already stored, explaining that leaving the field blank preserves the existing value.

- **Comprehensive test coverage**: Added four new unit tests covering:
  - Prevention of stored secret leakage in rendered output
  - Placeholder behavior when a secret is stored vs. when it's not
  - Preservation of existing secret when form is saved with empty submission
  - Replacement of secret when a new non-empty value is submitted

## Implementation Details

The security improvement addresses the risk of credential exposure through:
- Browser extensions inspecting DOM attributes
- Browser DevTools inspection
- Page caches storing HTML
- Autofill storage mechanisms
- Session state backups

The form now uses a two-step approach: render empty inputs with visual indicators, and intelligently preserve existing values during sanitization when the submitted value is empty.

https://claude.ai/code/session_014ePLsjq3jkcRsZNxnbqyX3