### PR TITLE
Refactor azp claim validation to match OIDC Core spec

### DIFF
--- a/includes/class-oidc-client.php
+++ b/includes/class-oidc-client.php
@@ -357,11 +357,14 @@ class OIDC_Client {
 			return new WP_Error( 'oidc_error', __( 'Invalid token audience.', 'secure-oidc-login' ) );
 		}
 
-		// If multiple audiences, verify azp claim matches client_id (OIDC Core spec 3.1.3.7)
-		if ( count( $aud ) > 1 ) {
-			if ( empty( $claims['azp'] ) || $claims['azp'] !== $client_id ) {
-				return new WP_Error( 'oidc_error', __( 'Invalid or missing azp claim for multi-audience token.', 'secure-oidc-login' ) );
-			}
+		// If multiple audiences, the azp claim MUST be present (OIDC Core spec 3.1.3.7, step 5).
+		if ( count( $aud ) > 1 && empty( $claims['azp'] ) ) {
+			return new WP_Error( 'oidc_error', __( 'Invalid or missing azp claim for multi-audience token.', 'secure-oidc-login' ) );
+		}
+
+		// If the azp claim is present, it MUST match client_id (OIDC Core spec 3.1.3.7, step 6).
+		if ( isset( $claims['azp'] ) && $claims['azp'] !== $client_id ) {
+			return new WP_Error( 'oidc_error', __( 'Invalid azp claim.', 'secure-oidc-login' ) );
 		}
 
 		// Validate nonce to prevent replay attacks (OIDC Core spec 3.1.3.7)


### PR DESCRIPTION
## Summary
Refactored the `azp` (authorized party) claim validation logic in the ID token validation method to more accurately align with the OIDC Core specification (section 3.1.3.7).

## Key Changes
- Split the combined azp validation into two separate, sequential checks:
  1. **Step 5**: When multiple audiences are present, the `azp` claim MUST be present
  2. **Step 6**: When the `azp` claim is present (regardless of audience count), it MUST match the `client_id`
- Updated validation logic from nested conditions to independent checks for clarity and spec compliance
- Improved error messages to distinguish between missing azp claims in multi-audience scenarios versus invalid azp values

## Implementation Details
- The refactored approach allows the `azp` claim to be validated independently when present, even in single-audience scenarios
- This change ensures stricter compliance with OIDC Core specification requirements for authorized party validation
- Comments now reference specific steps in the OIDC Core spec for better maintainability

https://claude.ai/code/session_01CK19s34MmEeDNu8oBNoYNN