### PR TITLE
Refactor get_callback_url to static method in main class

### DIFF
--- a/includes/class-oidc-client.php
+++ b/includes/class-oidc-client.php
@@ -182,7 +182,7 @@ class OIDC_Client {
 		$token_params = array(
 			'grant_type'   => 'authorization_code',  // Specifies the grant type being used
 			'code'         => $code,                 // The authorization code received from the IdP redirect
-			'redirect_uri' => $this->get_callback_url(), // Must match the redirect URI from the auth request
+			'redirect_uri' => Secure_OIDC_Login::get_callback_url(), // Must match the redirect URI from the auth request
 		);
 
 		// HTTP headers for the token request
@@ -1030,14 +1030,5 @@ class OIDC_Client {
 		}
 
 		return $config;
-	}
-
-	/**
-	 * Get the OIDC callback URL for this site.
-	 *
-	 * @return string The callback URL.
-	 */
-	private function get_callback_url(): string {
-		return add_query_arg( 'oidc_callback', '1', home_url( '/' ) );
 	}
 }

--- a/secure-oidc-login.php
+++ b/secure-oidc-login.php
@@ -472,7 +472,7 @@ class Secure_OIDC_Login {
 		set_transient( 'oidc_code_verifier_' . $state, $code_verifier, $state_ttl );
 		$code_challenge = $this->generate_code_challenge( $code_verifier );
 
-		$redirect_uri = $this->get_callback_url();
+		$redirect_uri = self::get_callback_url();
 		$scope        = 'openid email profile';
 
 		if ( ! empty( $options['scope'] ) ) {
@@ -781,7 +781,7 @@ class Secure_OIDC_Login {
 	 *
 	 * @return string The callback URL to be registered with the IdP.
 	 */
-	public function get_callback_url(): string {
+	public static function get_callback_url(): string {
 		return add_query_arg( 'oidc_callback', '1', home_url( '/' ) );
 	}
 

--- a/tests/stubs/class-secure-oidc-login.php
+++ b/tests/stubs/class-secure-oidc-login.php
@@ -36,4 +36,14 @@ class Secure_OIDC_Login
         // and just return the database/options value
         return (string) ($options[$option_key] ?? '');
     }
+
+    /**
+     * Get the OIDC callback URL for this site.
+     *
+     * @return string The callback URL to be registered with the IdP.
+     */
+    public static function get_callback_url(): string
+    {
+        return add_query_arg('oidc_callback', '1', home_url('/'));
+    }
 }


### PR DESCRIPTION
## Summary
This PR refactors the `get_callback_url()` method from an instance method to a static method in the `Secure_OIDC_Login` class, and removes the duplicate private implementation from the `OIDC_Client` class.

## Key Changes
- Converted `get_callback_url()` from instance method to static method in `Secure_OIDC_Login` class
- Updated all call sites to use static method syntax (`self::get_callback_url()` and `Secure_OIDC_Login::get_callback_url()`)
- Removed the duplicate private `get_callback_url()` method from `OIDC_Client` class
- Updated the test stub class to include the static `get_callback_url()` method

## Implementation Details
- The method generates the OIDC callback URL by appending the `oidc_callback` query parameter to the site's home URL
- Since this method has no instance dependencies, converting it to static improves code organization and allows it to be called without instantiation
- All three call sites have been updated: two in `secure-oidc-login.php` and one in `class-oidc-client.php`
- This eliminates code duplication and establishes a single source of truth for callback URL generation

https://claude.ai/code/session_01VRsu9yZMcEZdT7jYhYF647