### PR TITLE
Bind OIDC state to initiating browser (fix login-CSRF / session fixation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Bind the OIDC `state` to the initiating browser via an `HttpOnly` cookie, preventing login-CSRF / forced-login (session fixation)
+
 ## [1.3.1] - 2026-04-19
 
 ### Security

--- a/includes/class-oidc-state-binding.php
+++ b/includes/class-oidc-state-binding.php
@@ -30,7 +30,11 @@ class OIDC_State_Binding {
 	/**
 	 * Generate a fresh high-entropy browser-binding secret.
 	 *
-	 * @return string A 32-character alphanumeric secret.
+	 * Uses the URL/cookie-safe mixed-case alphanumeric set (a-z, A-Z, 0-9):
+	 * 32 chars over a 62-char alphabet is ~190 bits, well beyond what is needed,
+	 * while avoiding special characters that complicate cookie transport.
+	 *
+	 * @return string A 32-character mixed-case alphanumeric secret.
 	 */
 	public static function generate(): string {
 		return wp_generate_password( 32, false );
@@ -54,7 +58,10 @@ class OIDC_State_Binding {
 	 * @return bool True only when the cookie secret hashes to the stored value.
 	 */
 	public static function is_valid( $stored_hash, string $cookie_value ): bool {
-		if ( empty( $stored_hash ) || ! is_string( $stored_hash ) || '' === $cookie_value ) {
+		// Reject non-string stored values first (e.g. legacy `true` transients),
+		// then empty hash or empty cookie. Type check first makes the intent explicit
+		// and avoids empty()'s '0'-is-empty quirk (a SHA-256 hash is never empty/'0').
+		if ( ! is_string( $stored_hash ) || '' === $stored_hash || '' === $cookie_value ) {
 			return false;
 		}
 

--- a/includes/class-oidc-state-binding.php
+++ b/includes/class-oidc-state-binding.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+/**
+ * Browser binding for the OIDC authorization flow.
+ *
+ * Ties the CSRF `state` to the browser that initiated the login by issuing a
+ * secret cookie and storing only its hash server-side. Prevents login-CSRF /
+ * forced-login (session fixation): a browser that never received the cookie
+ * cannot redeem a captured `state`/`code` callback URL.
+ *
+ * @package Secure_OIDC_Login
+ * @since 1.3.2
+ */
+
+// Prevent direct file access
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Helper for binding the OIDC flow to the initiating browser.
+ *
+ * The binding secret is set as an HttpOnly cookie on the initiating browser;
+ * only its SHA-256 hash is persisted in the `oidc_state_$state` transient. On
+ * callback the flow proceeds only when SHA-256(cookie) matches the stored hash,
+ * which only the initiating browser can satisfy. The secret never appears in any
+ * URL, log, history, or Referer, and only its hash is stored server-side.
+ */
+class OIDC_State_Binding {
+	/**
+	 * Generate a fresh high-entropy browser-binding secret.
+	 *
+	 * @return string A 32-character alphanumeric secret.
+	 */
+	public static function generate(): string {
+		return wp_generate_password( 32, false );
+	}
+
+	/**
+	 * Hash a binding secret for server-side storage.
+	 *
+	 * @param string $secret The binding secret to hash.
+	 * @return string The SHA-256 hash of the secret.
+	 */
+	public static function hash( string $secret ): string {
+		return hash( 'sha256', $secret );
+	}
+
+	/**
+	 * Verify, in constant time, that a cookie secret matches the stored hash.
+	 *
+	 * @param mixed  $stored_hash  The hash stored in the state transient.
+	 * @param string $cookie_value The binding secret presented by the browser.
+	 * @return bool True only when the cookie secret hashes to the stored value.
+	 */
+	public static function is_valid( $stored_hash, string $cookie_value ): bool {
+		if ( empty( $stored_hash ) || ! is_string( $stored_hash ) || '' === $cookie_value ) {
+			return false;
+		}
+
+		return hash_equals( $stored_hash, self::hash( $cookie_value ) );
+	}
+}

--- a/secure-oidc-login.php
+++ b/secure-oidc-login.php
@@ -553,6 +553,8 @@ class Secure_OIDC_Login {
 		$stored_state = get_transient( 'oidc_state_' . $state );
 
 		if ( ! $stored_state ) {
+			// Clear any stale binding cookie from this expired/unknown flow.
+			$this->clear_state_cookie();
 			$this->handle_error( __( 'Invalid or expired state parameter.', 'secure-oidc-login' ) );
 			return;
 		}

--- a/secure-oidc-login.php
+++ b/secure-oidc-login.php
@@ -837,7 +837,7 @@ class Secure_OIDC_Login {
 			array(
 				'expires'  => time() + $ttl,
 				'path'     => defined( 'COOKIEPATH' ) && COOKIEPATH ? COOKIEPATH : '/',
-				'domain'   => defined( 'COOKIE_DOMAIN' ) ? COOKIE_DOMAIN : '',
+				'domain'   => ( defined( 'COOKIE_DOMAIN' ) && COOKIE_DOMAIN ) ? COOKIE_DOMAIN : '',
 				'secure'   => is_ssl(),
 				'httponly' => true,
 				'samesite' => 'Lax',
@@ -858,7 +858,7 @@ class Secure_OIDC_Login {
 			array(
 				'expires'  => time() - 3600,
 				'path'     => defined( 'COOKIEPATH' ) && COOKIEPATH ? COOKIEPATH : '/',
-				'domain'   => defined( 'COOKIE_DOMAIN' ) ? COOKIE_DOMAIN : '',
+				'domain'   => ( defined( 'COOKIE_DOMAIN' ) && COOKIE_DOMAIN ) ? COOKIE_DOMAIN : '',
 				'secure'   => is_ssl(),
 				'httponly' => true,
 				'samesite' => 'Lax',

--- a/secure-oidc-login.php
+++ b/secure-oidc-login.php
@@ -54,6 +54,7 @@ if ( ! class_exists( 'Firebase\JWT\JWT' ) ) {
 }
 
 require_once SECURE_OIDC_LOGIN_PLUGIN_DIR . 'includes/class-oidc-client.php';
+require_once SECURE_OIDC_LOGIN_PLUGIN_DIR . 'includes/class-oidc-state-binding.php';
 require_once SECURE_OIDC_LOGIN_PLUGIN_DIR . 'includes/class-oidc-admin.php';
 require_once SECURE_OIDC_LOGIN_PLUGIN_DIR . 'includes/class-oidc-user-handler.php';
 require_once SECURE_OIDC_LOGIN_PLUGIN_DIR . 'includes/class-oidc-token-crypto.php';
@@ -71,6 +72,13 @@ require_once SECURE_OIDC_LOGIN_PLUGIN_DIR . 'includes/class-oidc-token-refresh.p
  * @since 0.1.0
  */
 class Secure_OIDC_Login {
+	/**
+	 * Name of the cookie that binds the OIDC flow to the initiating browser.
+	 *
+	 * @var string
+	 */
+	const STATE_COOKIE = 'secure_oidc_state';
+
 	/** @var Secure_OIDC_Login|null Singleton instance */
 	private static $instance = null;
 
@@ -452,10 +460,15 @@ class Secure_OIDC_Login {
 		$state_ttl = $this->get_state_ttl();
 
 		// SECURITY: State parameter prevents CSRF attacks by linking the callback
-		// to this specific authorization request. Attackers cannot trick users into
-		// authenticating with an attacker-controlled account (session fixation).
-		$state = wp_generate_password( 32, false );
-		set_transient( 'oidc_state_' . $state, true, $state_ttl );
+		// to this specific authorization request. To prevent login-CSRF / forced-login
+		// (session fixation), the flow is also bound to the initiating browser: a fresh
+		// secret is set as an HttpOnly cookie and only its hash is stored server-side.
+		// On callback the flow proceeds only if the browser presents the matching cookie,
+		// so an attacker cannot trick a victim into completing the attacker's flow.
+		$state         = wp_generate_password( 32, false );
+		$state_binding = OIDC_State_Binding::generate();
+		$this->set_state_cookie( $state_binding, $state_ttl );
+		set_transient( 'oidc_state_' . $state, OIDC_State_Binding::hash( $state_binding ), $state_ttl );
 
 		// SECURITY: Nonce prevents token replay attacks. The nonce is embedded in
 		// the ID token by the IdP and must match our expected value. This ensures
@@ -544,7 +557,25 @@ class Secure_OIDC_Login {
 			return;
 		}
 
+		// SECURITY: Confirm this callback comes from the browser that initiated the
+		// flow. The state transient holds the hash of a secret that was set as an
+		// HttpOnly cookie on initiation; a forwarded callback opened in any other
+		// browser lacks that cookie and is rejected (login-CSRF / session fixation).
+		$state_cookie = isset( $_COOKIE[ self::STATE_COOKIE ] )
+			? sanitize_text_field( wp_unslash( $_COOKIE[ self::STATE_COOKIE ] ) )
+			: '';
+
+		if ( ! OIDC_State_Binding::is_valid( $stored_state, $state_cookie ) ) {
+			delete_transient( 'oidc_state_' . $state );
+			delete_transient( 'oidc_nonce_' . $state );
+			delete_transient( 'oidc_code_verifier_' . $state );
+			$this->clear_state_cookie();
+			$this->handle_error( __( 'Login could not be verified for this browser. Please try again.', 'secure-oidc-login' ) );
+			return;
+		}
+
 		delete_transient( 'oidc_state_' . $state );
+		$this->clear_state_cookie();
 
 		// Check for errors returned by the IdP
 		if ( ! empty( $_GET['error'] ) ) {
@@ -783,6 +814,54 @@ class Secure_OIDC_Login {
 	 */
 	public static function get_callback_url(): string {
 		return add_query_arg( 'oidc_callback', '1', home_url( '/' ) );
+	}
+
+	/**
+	 * Set the browser-binding cookie for the OIDC flow.
+	 *
+	 * SECURITY: SameSite=Lax (not Strict) is required so the cookie is sent on
+	 * the IdP's top-level cross-site redirect back to the callback. HttpOnly
+	 * keeps it out of JavaScript; Secure is gated on is_ssl() so HTTP dev still works.
+	 *
+	 * @since 1.3.2
+	 *
+	 * @param string $value The binding secret to store in the browser.
+	 * @param int    $ttl   Cookie lifetime in seconds (matches the state TTL).
+	 */
+	private function set_state_cookie( string $value, int $ttl ): void {
+		setcookie(
+			self::STATE_COOKIE,
+			$value,
+			array(
+				'expires'  => time() + $ttl,
+				'path'     => defined( 'COOKIEPATH' ) && COOKIEPATH ? COOKIEPATH : '/',
+				'domain'   => defined( 'COOKIE_DOMAIN' ) ? COOKIE_DOMAIN : '',
+				'secure'   => is_ssl(),
+				'httponly' => true,
+				'samesite' => 'Lax',
+			)
+		);
+	}
+
+	/**
+	 * Clear the browser-binding cookie once the flow is consumed.
+	 *
+	 * @since 1.3.2
+	 */
+	private function clear_state_cookie(): void {
+		unset( $_COOKIE[ self::STATE_COOKIE ] );
+		setcookie(
+			self::STATE_COOKIE,
+			'',
+			array(
+				'expires'  => time() - 3600,
+				'path'     => defined( 'COOKIEPATH' ) && COOKIEPATH ? COOKIEPATH : '/',
+				'domain'   => defined( 'COOKIE_DOMAIN' ) ? COOKIE_DOMAIN : '',
+				'secure'   => is_ssl(),
+				'httponly' => true,
+				'samesite' => 'Lax',
+			)
+		);
 	}
 
 	/**

--- a/tests/Unit/StateBinding/OIDCStateBindingTest.php
+++ b/tests/Unit/StateBinding/OIDCStateBindingTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Tests for OIDC_State_Binding class.
+ *
+ * @package SecureOIDCLogin\Tests\Unit\StateBinding
+ */
+
+declare(strict_types=1);
+
+namespace SecureOIDCLogin\Tests\Unit\StateBinding;
+
+use Brain\Monkey\Functions;
+use OIDC_State_Binding;
+use SecureOIDCLogin\Tests\OIDCTestCase;
+
+/**
+ * Tests for the OIDC_State_Binding browser-binding helper.
+ *
+ * @covers OIDC_State_Binding
+ */
+class OIDCStateBindingTest extends OIDCTestCase
+{
+    /**
+     * hash() returns the SHA-256 of the secret and is deterministic.
+     */
+    public function testHashMatchesSha256AndIsDeterministic(): void
+    {
+        $secret = 'abc123';
+
+        $this->assertSame(hash('sha256', $secret), OIDC_State_Binding::hash($secret));
+        $this->assertSame(
+            OIDC_State_Binding::hash($secret),
+            OIDC_State_Binding::hash($secret),
+            'Hashing the same secret must be deterministic'
+        );
+    }
+
+    /**
+     * generate() returns a 32-character secret from wp_generate_password().
+     */
+    public function testGenerateReturnsSecret(): void
+    {
+        Functions\expect('wp_generate_password')
+            ->once()
+            ->with(32, false)
+            ->andReturn('abcdefghijklmnopqrstuvwxyz012345');
+
+        $secret = OIDC_State_Binding::generate();
+
+        $this->assertIsString($secret);
+        $this->assertSame(32, strlen($secret));
+    }
+
+    /**
+     * A cookie secret that hashes to the stored value is accepted.
+     */
+    public function testIsValidAcceptsMatchingSecret(): void
+    {
+        $secret      = 'the-browser-binding-secret';
+        $stored_hash = OIDC_State_Binding::hash($secret);
+
+        $this->assertTrue(OIDC_State_Binding::is_valid($stored_hash, $secret));
+    }
+
+    /**
+     * A different cookie secret is rejected (this is the forced-login defense).
+     */
+    public function testIsValidRejectsWrongSecret(): void
+    {
+        $stored_hash = OIDC_State_Binding::hash('the-real-secret');
+
+        $this->assertFalse(OIDC_State_Binding::is_valid($stored_hash, 'attacker-secret'));
+    }
+
+    /**
+     * A missing/empty cookie is rejected (victim's browser has no binding cookie).
+     */
+    public function testIsValidRejectsEmptyCookie(): void
+    {
+        $stored_hash = OIDC_State_Binding::hash('the-real-secret');
+
+        $this->assertFalse(OIDC_State_Binding::is_valid($stored_hash, ''));
+    }
+
+    /**
+     * An empty or non-string stored hash is rejected.
+     */
+    public function testIsValidRejectsEmptyOrNonStringStoredHash(): void
+    {
+        $this->assertFalse(OIDC_State_Binding::is_valid('', 'some-secret'));
+        $this->assertFalse(OIDC_State_Binding::is_valid(false, 'some-secret'));
+        $this->assertFalse(OIDC_State_Binding::is_valid(null, 'some-secret'));
+        // Legacy `true` value (pre-fix transient contents) must not authenticate.
+        $this->assertFalse(OIDC_State_Binding::is_valid(true, 'some-secret'));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -70,6 +70,7 @@ require_once __DIR__ . '/stubs/class-secure-oidc-login.php';
 require_once dirname(__DIR__) . '/includes/class-oidc-token-crypto.php';
 require_once dirname(__DIR__) . '/includes/class-oidc-admin.php';
 require_once dirname(__DIR__) . '/includes/class-oidc-client.php';
+require_once dirname(__DIR__) . '/includes/class-oidc-state-binding.php';
 require_once dirname(__DIR__) . '/includes/class-oidc-user-handler.php';
 require_once dirname(__DIR__) . '/includes/class-oidc-rest-controller.php';
 require_once dirname(__DIR__) . '/includes/class-oidc-rate-limiter.php';


### PR DESCRIPTION
## Summary

Fixes **F-1 (High)** — the OIDC `state` had no browser binding, enabling login-CSRF / forced-login (session fixation).

The `state` was stored purely as a global server-side marker (`set_transient( 'oidc_state_' . $state, true, $ttl )`) with nothing tying it to the browser that initiated the flow. The PKCE `code_verifier` and `nonce` are keyed only by `$state`, and on callback `handle_callback()` validated `state` only by checking the transient was truthy. This degraded the CSRF control to a **global one-time nonce any browser could redeem**.

### Exploit (now blocked)
1. Attacker starts `/wp-login.php?oidc_login=1`, authenticates with their **own** IdP account.
2. The IdP redirects to `…/?oidc_callback=1&state=S&code=C`; the attacker captures this URL **without** following it, so `code` stays valid.
3. Attacker delivers that exact URL to a victim.
4. Victim clicks → `state` still exists → `code` is exchanged for the **attacker's** tokens → `wp_set_auth_cookie()` issues an auth cookie for the **attacker's** WordPress account in the victim's browser.

## Fix

Bind the flow to the initiating browser:
- On `initiate_login()`: mint a fresh random secret, set it as an `HttpOnly; SameSite=Lax; Secure` cookie (`secure_oidc_state`), and store **only its SHA-256 hash** in the `oidc_state_$state` transient (was `true`).
- On `handle_callback()`: proceed only when `SHA-256(cookie)` matches the stored hash (constant-time `hash_equals`). On failure, clear the state/nonce/code_verifier transients and the cookie; on success, clear the cookie once the state is consumed.

A forwarded callback opened in any other browser lacks the cookie and is rejected. The binding secret never appears in any URL, log, history, or `Referer` — only its hash is stored server-side.

### Why `SameSite=Lax` (not `Strict`)
The IdP's redirect back to the callback is a top-level **cross-site** GET navigation; `Strict` would withhold the cookie and break legitimate logins. `Lax` sends it on top-level navigations, which is exactly the callback. `HttpOnly` (JS never needs it) and `Secure` gated on `is_ssl()` (so HTTP dev still works).

## Changes
- **New** `includes/class-oidc-state-binding.php` — `OIDC_State_Binding` helper (`generate` / `hash` / constant-time `is_valid`). Isolated as the testable seam since the main class is stubbed in the test harness.
- `secure-oidc-login.php` — cookie set/validate/clear, store hash instead of `true`, `STATE_COOKIE` constant, corrected the (previously inaccurate) session-fixation comment.
- `tests/Unit/StateBinding/OIDCStateBindingTest.php` + bootstrap registration — covers matching secret, wrong secret, missing cookie, and empty/non-string/legacy-`true` stored hash.
- `CHANGELOG.md` — Security entry under `[Unreleased]`.

## Verification
- `composer test`: **422 tests pass** (incl. 6 new). The non-zero exit is pre-existing PHP 8.5 deprecations + "no coverage driver" warning + 1 pre-existing skip — no failures.
- `composer phpstan`: no errors. `composer phpcs`: clean.

## Reviewer notes
- **Manual E2E still needed** (requires a live IdP): capture a callback URL in browser A, confirm it's rejected in browser B with no cookie, confirm normal login in browser A still works, and verify the cookie attributes/clearing in dev tools.
- A second login started in the same browser overwrites the single binding cookie, so only the most recent in-flight login per browser can complete — acceptable/standard.
- Users who block cookies for the site can't complete login; the error message guides them to retry.
- No version bump here — left to the normal release process; the `[Unreleased]` CHANGELOG entry covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)