### PR TITLE
Test validate_id_token nonce branches + fails-closed nonce path

### DIFF
--- a/tests/Unit/Client/OIDCClientTest.php
+++ b/tests/Unit/Client/OIDCClientTest.php
@@ -1577,16 +1577,126 @@ class OIDCClientTest extends OIDCTestCase
     }
 
     /**
-     * Test that nonce validation is case-sensitive.
+     * Test validate_id_token skips nonce validation when no nonce is expected.
+     *
+     * Covers the null-skip branch: when $expected_nonce is null, the nonce claim
+     * is neither required nor compared.
+     */
+    public function testValidateIdTokenSkipsNonceCheckWhenExpectedNonceIsNull(): void
+    {
+        $client = $this->createClientWithStubbedJwt([
+            'sub' => 'user-123',
+            'iss' => 'https://idp.example.com',
+            'aud' => 'test-client-id',
+            // No 'nonce' claim — must still succeed when none is expected.
+        ]);
+
+        $result = $client->validate_id_token('fake.jwt.token', null);
+
+        $this->assertIsArray($result);
+        $this->assertSame('user-123', $result['sub']);
+    }
+
+    /**
+     * Test validate_id_token rejects a token missing the nonce claim when one is expected.
+     *
+     * Covers the missing-claim branch (OIDC Core 3.1.3.7).
+     */
+    public function testValidateIdTokenRejectsMissingNonceClaim(): void
+    {
+        $client = $this->createClientWithStubbedJwt([
+            'sub' => 'user-123',
+            'iss' => 'https://idp.example.com',
+            'aud' => 'test-client-id',
+            // No 'nonce' claim, but a nonce is expected below.
+        ]);
+
+        $result = $client->validate_id_token('fake.jwt.token', 'expected-nonce-value');
+
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame('missing_nonce', $result->get_error_code());
+    }
+
+    /**
+     * Test validate_id_token rejects a nonce that does not match the expected value.
+     *
+     * Covers the mismatch branch — the core replay-attack defense.
+     */
+    public function testValidateIdTokenRejectsMismatchedNonce(): void
+    {
+        $client = $this->createClientWithStubbedJwt([
+            'sub' => 'user-123',
+            'iss' => 'https://idp.example.com',
+            'aud' => 'test-client-id',
+            'nonce' => 'actual-nonce-from-token',
+        ]);
+
+        $result = $client->validate_id_token('fake.jwt.token', 'different-expected-nonce');
+
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame('invalid_nonce', $result->get_error_code());
+    }
+
+    /**
+     * Test validate_id_token accepts a token whose nonce matches the expected value.
+     */
+    public function testValidateIdTokenAcceptsMatchingNonce(): void
+    {
+        $client = $this->createClientWithStubbedJwt([
+            'sub' => 'user-123',
+            'iss' => 'https://idp.example.com',
+            'aud' => 'test-client-id',
+            'nonce' => 'matching-nonce',
+        ]);
+
+        $result = $client->validate_id_token('fake.jwt.token', 'matching-nonce');
+
+        $this->assertIsArray($result);
+        $this->assertSame('user-123', $result['sub']);
+    }
+
+    /**
+     * Test that nonce validation is case-sensitive (strict comparison).
      */
     public function testNonceValidationIsCaseSensitive(): void
     {
-        // This is tested by verifying the method uses strict comparison
-        // Actual validation tested via validate_id_token integration
-        $nonce1 = 'TestNonce123';
-        $nonce2 = 'testnonce123';
+        $client = $this->createClientWithStubbedJwt([
+            'sub' => 'user-123',
+            'iss' => 'https://idp.example.com',
+            'aud' => 'test-client-id',
+            'nonce' => 'TestNonce123',
+        ]);
 
-        $this->assertNotSame($nonce1, $nonce2, 'Nonces should be case-sensitive');
+        // Same characters, different case — must be rejected by the strict (!==) check.
+        $result = $client->validate_id_token('fake.jwt.token', 'testnonce123');
+
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertSame('invalid_nonce', $result->get_error_code());
+    }
+
+    /**
+     * Test the expired/missing nonce-transient path fails closed.
+     *
+     * In handle_callback the expected nonce comes from get_transient(), which
+     * returns false when the transient is missing or expired. Under strict_types
+     * that false hits the ?string $expected_nonce parameter and throws a
+     * TypeError, aborting authentication rather than silently skipping the nonce
+     * check (which null would do). This locks in that fails-closed guarantee.
+     */
+    public function testValidateIdTokenRejectsNonStringNonceFromExpiredTransient(): void
+    {
+        $client = $this->createClientWithStubbedJwt([
+            'sub' => 'user-123',
+            'iss' => 'https://idp.example.com',
+            'aud' => 'test-client-id',
+            'nonce' => 'some-nonce',
+        ]);
+
+        $this->expectException(\TypeError::class);
+
+        // false is what get_transient() returns for a missing/expired nonce; it
+        // must not be accepted as "no nonce expected".
+        $client->validate_id_token('fake.jwt.token', false);
     }
 
     /**


### PR DESCRIPTION
## What & why

Appendix B item **#3** (nonce-logic scope). `validate_id_token`'s nonce branches had no real test coverage, and the existing `testNonceValidationIsCaseSensitive` was a placeholder that only asserted two string literals differ — it never called the method under test. This is security-critical replay-attack defense (OIDC Core 3.1.3.7), so it should be locked down by tests.

## Changes (all in `tests/Unit/Client/OIDCClientTest.php`)

Using the existing `createClientWithStubbedJwt([...claims])` helper (injects claims past signature verification):

- **null-skip** — no nonce expected → nonce claim neither required nor compared (success).
- **missing-claim** — nonce expected but absent → `WP_Error('missing_nonce')`.
- **mismatch** — token nonce ≠ expected → `WP_Error('invalid_nonce')`.
- **match** — correct nonce → success.
- **case-sensitivity** — rewrote the placeholder to actually call `validate_id_token` and assert `invalid_nonce` on a case-only difference (verifies the strict `!==` comparison).
- **fails-closed** — a `false` value (what `get_transient()` returns for a missing/expired nonce) passed to the `?string $expected_nonce` parameter throws `TypeError` under `strict_types`, documenting that the callback **aborts** rather than silently skipping the nonce check (which `null` would do).

## Scope / notes for reviewers

- **Deferred:** full `handle_callback` orchestration tests. `Secure_OIDC_Login` is a singleton with a private constructor and internally-wired collaborators (no DI), and `handle_callback` lives in `secure-oidc-login.php` — which is **codecov-ignored** (item **#4**). Those tests are coupled to #4 (un-ignoring the file so coverage counts), so they belong in that branch.
- The `TypeError` test passes a literal `false` intentionally; this is safe for CI because PHPStan analyzes only `secure-oidc-login.php` + `includes/` (not `tests/`), and phpcs excludes `tests/`.
- Full suite: 429 tests pass (was 424; +5 net).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for OpenID Connect token nonce validation, ensuring proper handling of multiple scenarios including null nonce values, missing nonce claims, case-sensitive matching, and edge cases with invalid data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->