### PR TITLE
Correct the codecov ignore justification for secure-oidc-login.php

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,7 +12,13 @@ ignore:
   - "vendor/**/*"
   - "tests/**/*"
   - "build/**/*"
-  - "secure-oidc-login.php"  # Bootstrap file with initialization code - tested via integration tests
+  # Bootstrap + request-lifecycle code: registers WordPress hooks and runs the
+  # OIDC callback/login/logout flows, which complete by redirecting and calling
+  # exit(), so they cannot be exercised in-process by unit tests. The security-
+  # critical logic these flows delegate to IS unit-tested under tests/Unit/
+  # (ID-token/nonce validation, user provisioning, token storage, rate limiting,
+  # state binding); end-to-end behavior is verified manually.
+  - "secure-oidc-login.php"
 
 comment:
   layout: "reach,diff,flags,files"


### PR DESCRIPTION
## What & why

Appendix B item **#4**. `codecov.yml` ignored `secure-oidc-login.php` with the justification *"Bootstrap file with initialization code - tested via integration tests"* — but **no integration suite exists** (only `tests/Unit/`). That made the ignore's rationale misleading. This PR replaces it with an accurate explanation.

## Why keep the file ignored (not un-ignore it)

Investigated un-ignoring + adding `handle_callback` tests, and hit two blockers that make "honest comment" the right call:

1. **`handle_callback` isn't unit-testable as written.** `handle_error()` and the success path both end in a bare **`exit;`**, and every error/early-return branch routes through `handle_error()`. PHPUnit can't intercept a bare `exit` (Brain Monkey mocks functions, not language constructs; process isolation can't record a clean exit as a pass). Making it testable would require a production refactor of the error/exit flow — out of scope here.
2. **Un-ignoring exposes ~1015 lines of mostly-untestable lifecycle glue** (hook registration, `init`, REST route registration, `activate`/`deactivate`) to the 70% project gate, which would either fail the gate or pressure low-value tests for bootstrap code.

Crucially, the **security-critical logic** `handle_callback` delegates to is already unit-tested under `tests/Unit/`:
- ID-token / nonce validation (`OIDCClientTest` — incl. the nonce branches added in #67)
- user provisioning (`OIDCUserHandlerTest`)
- token storage (`OIDCTokenManagerTest`)
- rate limiting (`OIDCRateLimiterTest`)
- state binding (`OIDCStateBindingTest`)

## Change

`codecov.yml` only — the ignore entry keeps `secure-oidc-login.php` but the comment now truthfully describes it as bootstrap/request-lifecycle code that exits on completion, with its delegated logic unit-tested and end-to-end behavior verified manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration file with clarified documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->