### PR TITLE
Harden OIDC authentication: discovery issuer validation, RFC 9207 iss check, refresh lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 - Bind the OIDC `state` to the initiating browser via an `HttpOnly` cookie, preventing login-CSRF / forced-login (session fixation)
+- Validate the discovery document `issuer` against the discovery URL (OIDC Discovery 1.0 §4.3) and require HTTPS on all advertised endpoints
+- Validate the RFC 9207 `iss` authorization response parameter on the callback; required when the IdP advertises support during discovery (IdP mix-up defense)
+- Form-urlencode `client_id`/`client_secret` in HTTP Basic credentials per RFC 6749 §2.3.1
+- Drop JWKS keys with an unknown `kty` instead of assigning them the JWT header algorithm
+
+### Added
+- "Remember Users" login setting and `secure_oidc_login_remember_user` filter to control the persistent 14-day auth cookie (previously always enabled)
+- `client_id` parameter on RP-initiated logout requests per OIDC RP-Initiated Logout 1.0
+
+### Fixed
+- Serialize automatic token refresh with a per-user lock so parallel requests cannot replay a rotated refresh token (which rotation-enforcing IdPs treat as reuse and may revoke the session)
+- Validate refresh token responses (`access_token` presence, Bearer `token_type`) in the client like the login-time token exchange
+- Lower the token refresh HTTP timeout from 30s to 10s so a slow IdP cannot block page loads for half a minute
 
 ## [1.3.1] - 2026-04-19
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Navigate to **Settings > OIDC Auth** in your WordPress admin panel.
 |---------|-------------|
 | Login Button Text | Text displayed on the SSO login button |
 | Enable Single Logout | When enabled, logging out of WordPress also logs out of the IdP |
+| Remember Users | Keep users logged in with WordPress's persistent 14-day cookie (default). Disable to use a session cookie that expires when the browser closes, aligning the WordPress session more closely with the IdP session. Also filterable via `secure_oidc_login_remember_user`. |
 
 #### User Settings
 

--- a/assets/js/admin-settings.js
+++ b/assets/js/admin-settings.js
@@ -67,6 +67,12 @@
 						JSON.stringify(algValues)
 					);
 
+					// Record whether the IdP supports the RFC 9207 iss response parameter.
+					// When supported, the callback requires and validates it (mix-up defense).
+					$('input[name="secure_oidc_login_settings[authorization_response_iss_parameter_supported]"]').val(
+						config.authorization_response_iss_parameter_supported === true ? '1' : '0'
+					);
+
 					alert(oidcAdminSettings.i18n.discoverySuccess);
 				},
 				error: function(xhr) {

--- a/includes/class-oidc-admin.php
+++ b/includes/class-oidc-admin.php
@@ -834,11 +834,17 @@ class OIDC_Admin {
 		}
 
 		// Sanitize authorization_response_iss_parameter_supported (hidden field set by
-		// discovery to '1' or '0'). An empty value means discovery did not run on this
-		// form submission, so the previously stored value is preserved.
+		// discovery to '1' or '0'; rendered empty otherwise). An empty value means
+		// discovery did not run on this form submission.
 		$iss_input = $input['authorization_response_iss_parameter_supported'] ?? '';
 		if ( '1' === $iss_input || '0' === $iss_input ) {
 			$sanitized['authorization_response_iss_parameter_supported'] = ( '1' === $iss_input );
+		} elseif ( ( $sanitized['issuer'] ?? '' ) !== ( $existing_settings['issuer'] ?? '' ) ) {
+			// SECURITY: The flag was discovered for a specific issuer. If the issuer
+			// changes without a fresh discovery, the old provider's value must not
+			// carry over — the new IdP may not send the RFC 9207 iss parameter, and a
+			// stale "required" flag would hard-break every login against it.
+			$sanitized['authorization_response_iss_parameter_supported'] = false;
 		} else {
 			$sanitized['authorization_response_iss_parameter_supported'] = ! empty( $existing_settings['authorization_response_iss_parameter_supported'] );
 		}
@@ -1004,16 +1010,13 @@ class OIDC_Admin {
 	 *
 	 * Auto-populated during OIDC discovery from the IdP's
 	 * authorization_response_iss_parameter_supported value ('1' or '0').
-	 * An empty value means discovery has not run; the stored value is preserved.
+	 * The field is always rendered empty: a non-empty value proves discovery ran
+	 * on this form submission, which lets sanitize_settings() distinguish a fresh
+	 * discovery result from a stale flag carried over from a previous provider.
 	 */
 	public function render_iss_parameter_hidden_field(): void {
-		$options = get_option( 'secure_oidc_login_settings', array() );
-		$value   = '';
-		if ( isset( $options['authorization_response_iss_parameter_supported'] ) ) {
-			$value = $options['authorization_response_iss_parameter_supported'] ? '1' : '0';
-		}
 		?>
-		<input type="hidden" name="secure_oidc_login_settings[authorization_response_iss_parameter_supported]" value="<?php echo esc_attr( $value ); ?>">
+		<input type="hidden" name="secure_oidc_login_settings[authorization_response_iss_parameter_supported]" value="">
 		<?php
 	}
 

--- a/includes/class-oidc-admin.php
+++ b/includes/class-oidc-admin.php
@@ -242,6 +242,16 @@ class OIDC_Admin {
 			'oidc_provider_section'
 		);
 
+		// Hidden field recording whether the IdP supports the RFC 9207 iss response
+		// parameter (populated by discovery; enforced on the OIDC callback when true)
+		add_settings_field(
+			'authorization_response_iss_parameter_supported',
+			'',
+			array( $this, 'render_iss_parameter_hidden_field' ),
+			'secure-oidc-login',
+			'oidc_provider_section'
+		);
+
 		add_settings_field(
 			'client_id',
 			__( 'Client ID', 'secure-oidc-login' ),
@@ -434,6 +444,19 @@ class OIDC_Admin {
 			array(
 				'field'       => 'disable_native_login',
 				'description' => __( 'Hide username/password form and block native authentication. Emergency access: add ?native=1 to login URL.', 'secure-oidc-login' ),
+			)
+		);
+
+		add_settings_field(
+			'remember_user',
+			__( 'Remember Users', 'secure-oidc-login' ),
+			array( $this, 'render_checkbox_field' ),
+			'secure-oidc-login',
+			'oidc_login_section',
+			array(
+				'field'       => 'remember_user',
+				'default'     => true,
+				'description' => __( 'Keep users logged in with a persistent 14-day cookie. Disable to use a session cookie so the WordPress session ends when the browser closes, aligning more closely with the identity provider session.', 'secure-oidc-login' ),
 			)
 		);
 
@@ -653,7 +676,7 @@ class OIDC_Admin {
 		);
 
 		// Boolean checkbox fields
-		$checkbox_fields = array( 'enable_single_logout', 'create_users', 'require_verified_email', 'disable_native_login', 'enable_auto_token_refresh', 'enforce_refresh_token_rotation', 'enforce_acr' );
+		$checkbox_fields = array( 'enable_single_logout', 'create_users', 'require_verified_email', 'disable_native_login', 'enable_auto_token_refresh', 'enforce_refresh_token_rotation', 'enforce_acr', 'remember_user' );
 
 		// Integer number fields with validation
 		$number_fields = array(
@@ -810,6 +833,16 @@ class OIDC_Admin {
 			$sanitized['id_token_signing_alg_values_supported'] = $existing_settings['id_token_signing_alg_values_supported'] ?? array();
 		}
 
+		// Sanitize authorization_response_iss_parameter_supported (hidden field set by
+		// discovery to '1' or '0'). An empty value means discovery did not run on this
+		// form submission, so the previously stored value is preserved.
+		$iss_input = $input['authorization_response_iss_parameter_supported'] ?? '';
+		if ( '1' === $iss_input || '0' === $iss_input ) {
+			$sanitized['authorization_response_iss_parameter_supported'] = ( '1' === $iss_input );
+		} else {
+			$sanitized['authorization_response_iss_parameter_supported'] = ! empty( $existing_settings['authorization_response_iss_parameter_supported'] );
+		}
+
 		return $sanitized;
 	}
 
@@ -963,6 +996,24 @@ class OIDC_Admin {
 		}
 		?>
 		<input type="hidden" name="secure_oidc_login_settings[id_token_signing_alg_values_supported]" value="<?php echo esc_attr( $value ); ?>">
+		<?php
+	}
+
+	/**
+	 * Render a hidden field recording RFC 9207 iss response parameter support.
+	 *
+	 * Auto-populated during OIDC discovery from the IdP's
+	 * authorization_response_iss_parameter_supported value ('1' or '0').
+	 * An empty value means discovery has not run; the stored value is preserved.
+	 */
+	public function render_iss_parameter_hidden_field(): void {
+		$options = get_option( 'secure_oidc_login_settings', array() );
+		$value   = '';
+		if ( isset( $options['authorization_response_iss_parameter_supported'] ) ) {
+			$value = $options['authorization_response_iss_parameter_supported'] ? '1' : '0';
+		}
+		?>
+		<input type="hidden" name="secure_oidc_login_settings[authorization_response_iss_parameter_supported]" value="<?php echo esc_attr( $value ); ?>">
 		<?php
 	}
 
@@ -1157,7 +1208,8 @@ class OIDC_Admin {
 	public function render_checkbox_field( array $args ): void {
 		$options = get_option( 'secure_oidc_login_settings', array() );
 		$field   = $args['field'];
-		$checked = isset( $options[ $field ] ) && $options[ $field ] ? 'checked' : '';
+		$default = ! empty( $args['default'] );
+		$checked = ( $options[ $field ] ?? $default ) ? 'checked' : '';
 
 		// Check if this setting is overridden by environment variable
 		$env_var           = 'SECURE_OIDC_' . strtoupper( $field );

--- a/includes/class-oidc-client.php
+++ b/includes/class-oidc-client.php
@@ -158,6 +158,45 @@ class OIDC_Client {
 	}
 
 	/**
+	 * Apply client authentication to a token endpoint request.
+	 *
+	 * Confidential clients authenticate per RFC 6749 section 2.3. The method is
+	 * configurable: client_secret_basic (Authorization header) or client_secret_post
+	 * (request body). Public clients include client_id in the body for identification.
+	 *
+	 * @param array<string, string> $token_params Token request body parameters.
+	 * @param array<string, string> $headers      Token request HTTP headers.
+	 * @return array{0: array<string, string>, 1: array<string, string>} Updated [params, headers].
+	 */
+	private function apply_client_authentication( array $token_params, array $headers ): array {
+		$client_id     = $this->get_setting( 'client_id' );
+		$client_secret = $this->get_setting( 'client_secret' );
+
+		if ( ! empty( $client_secret ) ) {
+			$auth_method = $this->get_setting( 'token_endpoint_auth_method' );
+
+			if ( 'client_secret_post' === $auth_method ) {
+				// client_secret_post: credentials sent in the request body (RFC 6749 section 2.3.1)
+				$token_params['client_id']     = $client_id;
+				$token_params['client_secret'] = $client_secret;
+			} else {
+				// client_secret_basic (default): credentials in Authorization header only.
+				// Per RFC 6749 section 2.3.1, clients using Basic auth MUST NOT include
+				// credentials in the request body, and the client_id and client_secret
+				// MUST each be form-urlencoded before being combined with a colon and
+				// base64-encoded. This matters for secrets containing ':', '%', '+', etc.
+				$credentials              = rawurlencode( $client_id ) . ':' . rawurlencode( $client_secret );
+				$headers['Authorization'] = 'Basic ' . base64_encode( $credentials );
+			}
+		} else {
+			// Public clients: include client_id in body for identification
+			$token_params['client_id'] = $client_id;
+		}
+
+		return array( $token_params, $headers );
+	}
+
+	/**
 	 * Exchange an authorization code for access and ID tokens.
 	 *
 	 * Performs the token endpoint request as part of the authorization code flow.
@@ -174,10 +213,6 @@ class OIDC_Client {
 			return new WP_Error( 'oidc_error', __( 'Token endpoint not configured.', 'secure-oidc-login' ) );
 		}
 
-		// Get client credentials (check env vars first)
-		$client_id     = $this->get_setting( 'client_id' );
-		$client_secret = $this->get_setting( 'client_secret' );
-
 		// Token endpoint request parameters for OAuth 2.0 Authorization Code Flow
 		$token_params = array(
 			'grant_type'   => 'authorization_code',  // Specifies the grant type being used
@@ -191,26 +226,7 @@ class OIDC_Client {
 			'Content-Type' => 'application/x-www-form-urlencoded',
 		);
 
-		// Confidential clients authenticate per RFC 6749 section 2.3
-		// The method is configurable: client_secret_basic (header) or client_secret_post (body)
-		if ( ! empty( $client_secret ) ) {
-			$auth_method = $this->get_setting( 'token_endpoint_auth_method' );
-
-			if ( 'client_secret_post' === $auth_method ) {
-				// client_secret_post: credentials sent in the request body (RFC 6749 section 2.3.1)
-				$token_params['client_id']     = $client_id;
-				$token_params['client_secret'] = $client_secret;
-			} else {
-				// client_secret_basic (default): credentials in Authorization header only
-				// Per RFC 6749 section 2.3.1, clients using Basic auth MUST NOT include
-				// credentials in the request body
-				$credentials              = $client_id . ':' . $client_secret;
-				$headers['Authorization'] = 'Basic ' . base64_encode( $credentials );
-			}
-		} else {
-			// Public clients: include client_id in body for identification
-			$token_params['client_id'] = $client_id;
-		}
+		list( $token_params, $headers ) = $this->apply_client_authentication( $token_params, $headers );
 
 		// Public clients use PKCE for security (no client_secret available)
 		if ( ! empty( $code_verifier ) ) {
@@ -525,14 +541,20 @@ class OIDC_Client {
 		// The Firebase JWT library requires it, so we infer from the key type (kty) when missing.
 		// SECURITY: We derive the algorithm from the trusted JWKS key type rather than copying
 		// the attacker-controlled JWT header value, preventing algorithm confusion attacks.
+		// Keys with an unknown kty are dropped entirely instead of inheriting the header value.
 		if ( isset( $jwks['keys'] ) && is_array( $jwks['keys'] ) ) {
-			foreach ( $jwks['keys'] as &$key ) {
+			$usable_keys = array();
+			foreach ( $jwks['keys'] as $key ) {
 				if ( ! isset( $key['alg'] ) ) {
-					$kty        = isset( $key['kty'] ) ? $key['kty'] : '';
-					$key['alg'] = isset( self::KTY_DEFAULT_ALGORITHM[ $kty ] ) ? self::KTY_DEFAULT_ALGORITHM[ $kty ] : $alg;
+					$kty = isset( $key['kty'] ) ? $key['kty'] : '';
+					if ( ! isset( self::KTY_DEFAULT_ALGORITHM[ $kty ] ) ) {
+						continue;
+					}
+					$key['alg'] = self::KTY_DEFAULT_ALGORITHM[ $kty ];
 				}
+				$usable_keys[] = $key;
 			}
-			unset( $key ); // Break reference to avoid unexpected behavior
+			$jwks['keys'] = $usable_keys;
 		}
 
 		try {
@@ -878,10 +900,6 @@ class OIDC_Client {
 			return new WP_Error( 'oidc_error', __( 'Token endpoint not configured.', 'secure-oidc-login' ) );
 		}
 
-		// Get client credentials (check env vars first)
-		$client_id     = $this->get_setting( 'client_id' );
-		$client_secret = $this->get_setting( 'client_secret' );
-
 		$token_params = array(
 			'grant_type'    => 'refresh_token',
 			'refresh_token' => $refresh_token,
@@ -891,35 +909,18 @@ class OIDC_Client {
 			'Content-Type' => 'application/x-www-form-urlencoded',
 		);
 
-		// Confidential clients authenticate per RFC 6749 section 2.3
-		// The method is configurable: client_secret_basic (header) or client_secret_post (body)
-		if ( ! empty( $client_secret ) ) {
-			$auth_method = $this->get_setting( 'token_endpoint_auth_method' );
-
-			if ( 'client_secret_post' === $auth_method ) {
-				// client_secret_post: credentials sent in the request body (RFC 6749 section 2.3.1)
-				$token_params['client_id']     = $client_id;
-				$token_params['client_secret'] = $client_secret;
-			} else {
-				// client_secret_basic (default): credentials in Authorization header only
-				// Per RFC 6749 section 2.3.1, clients using Basic auth MUST NOT include
-				// credentials in the request body
-				$credentials              = $client_id . ':' . $client_secret;
-				$headers['Authorization'] = 'Basic ' . base64_encode( $credentials );
-			}
-		} else {
-			// Public clients: include client_id in body for identification
-			$token_params['client_id'] = $client_id;
-		}
+		list( $token_params, $headers ) = $this->apply_client_authentication( $token_params, $headers );
 
 		// SECURITY: Use wp_safe_remote_post() to prevent SSRF attacks
 		// This validates the token_endpoint URL and blocks private IPs, non-standard ports, etc.
+		// Timeout is shorter than the login-time token exchange because refresh runs
+		// synchronously on init and would otherwise block page loads on a slow IdP.
 		$response = wp_safe_remote_post(
 			$token_endpoint,
 			array(
 				'body'    => $token_params,
 				'headers' => $headers,
-				'timeout' => 30,
+				'timeout' => 10,
 			)
 		);
 
@@ -969,6 +970,28 @@ class OIDC_Client {
 				'token_refresh',
 				$detailed_error,
 				__( 'Session refresh failed. Please log in again.', 'secure-oidc-login' )
+			);
+		}
+
+		// Validate the refresh response shape like exchange_code() does, so every
+		// caller gets the same guarantees (RFC 6749 section 5.1: access_token and
+		// token_type are REQUIRED; only Bearer tokens are supported).
+		if ( ! is_array( $tokens ) || empty( $tokens['access_token'] ) ) {
+			return new WP_Error( 'oidc_error', __( 'Invalid token response.', 'secure-oidc-login' ) );
+		}
+
+		if ( empty( $tokens['token_type'] ) ) {
+			return new WP_Error( 'oidc_error', __( 'Missing required token_type in token response.', 'secure-oidc-login' ) );
+		}
+
+		if ( strcasecmp( $tokens['token_type'], 'Bearer' ) !== 0 ) {
+			return new WP_Error(
+				'oidc_error',
+				sprintf(
+					/* translators: %s: token type returned by IdP */
+					__( 'Unsupported token type: %s. Only Bearer tokens are supported.', 'secure-oidc-login' ),
+					$tokens['token_type']
+				)
 			);
 		}
 
@@ -1025,10 +1048,104 @@ class OIDC_Client {
 		$config = json_decode( $body, true );
 
 		// If the config is invalid, return an error.
-		if ( ! $config ) {
+		if ( ! $config || ! is_array( $config ) ) {
 			return new WP_Error( 'oidc_error', __( 'Invalid discovery response.', 'secure-oidc-login' ) );
 		}
 
+		$validation = self::validate_discovery_document( $config, $discovery_url );
+		if ( is_wp_error( $validation ) ) {
+			return $validation;
+		}
+
 		return $config;
+	}
+
+	/**
+	 * Validate an OpenID Provider Configuration document against the URL it was fetched from.
+	 *
+	 * SECURITY: Per OIDC Discovery 1.0 Section 4.3, the issuer in the document MUST be
+	 * the discovery URL with the /.well-known/openid-configuration suffix removed. A
+	 * mismatch means the document describes a different issuer than the one queried
+	 * (misconfiguration, or an attempt to point this client at another provider's
+	 * endpoints — the precondition for IdP mix-up attacks). Endpoint URLs must also be
+	 * HTTPS unless SECURE_OIDC_ALLOW_INSECURE_DISCOVERY=true is set for testing.
+	 *
+	 * @param array<string, mixed> $config        The decoded discovery document.
+	 * @param string               $discovery_url The URL the document was fetched from.
+	 * @return true|WP_Error True if the document is valid, WP_Error otherwise.
+	 */
+	public static function validate_discovery_document( array $config, string $discovery_url ): bool|WP_Error {
+		$issuer = $config['issuer'] ?? '';
+
+		if ( ! is_string( $issuer ) || '' === $issuer ) {
+			return new WP_Error(
+				'oidc_discovery_missing_issuer',
+				__( 'Discovery document is missing the required issuer field.', 'secure-oidc-login' )
+			);
+		}
+
+		// Strip query string and fragment before comparing — some providers (e.g. Azure AD B2C)
+		// require query parameters on the discovery URL that are not part of the issuer.
+		$normalized_url = strtok( $discovery_url, '?#' );
+		$expected_url   = rtrim( $issuer, '/' ) . '/.well-known/openid-configuration';
+
+		if ( rtrim( (string) $normalized_url, '/' ) !== $expected_url ) {
+			return new WP_Error(
+				'oidc_discovery_issuer_mismatch',
+				sprintf(
+					/* translators: 1: issuer value from the discovery document, 2: discovery URL */
+					__( 'Discovery document issuer "%1$s" does not match the discovery URL "%2$s". Refusing to use this configuration.', 'secure-oidc-login' ),
+					$issuer,
+					$discovery_url
+				)
+			);
+		}
+
+		// Require HTTPS on all advertised endpoints (matches the HTTPS requirement
+		// already enforced for the discovery URL itself).
+		$allow_insecure = getenv( 'SECURE_OIDC_ALLOW_INSECURE_DISCOVERY' );
+		$require_https  = false === $allow_insecure || 'true' !== strtolower( (string) $allow_insecure );
+
+		$endpoint_keys = array(
+			'authorization_endpoint',
+			'token_endpoint',
+			'jwks_uri',
+			'userinfo_endpoint',
+			'end_session_endpoint',
+		);
+
+		foreach ( $endpoint_keys as $key ) {
+			if ( empty( $config[ $key ] ) ) {
+				continue;
+			}
+
+			$endpoint = $config[ $key ];
+
+			if ( ! is_string( $endpoint ) || false === filter_var( $endpoint, FILTER_VALIDATE_URL ) ) {
+				return new WP_Error(
+					'oidc_discovery_invalid_endpoint',
+					sprintf(
+						/* translators: %s: discovery document field name */
+						__( 'Discovery document contains an invalid %s URL.', 'secure-oidc-login' ),
+						$key
+					)
+				);
+			}
+
+			$parsed = wp_parse_url( $endpoint );
+			$scheme = is_array( $parsed ) && isset( $parsed['scheme'] ) ? strtolower( (string) $parsed['scheme'] ) : '';
+			if ( $require_https && 'https' !== $scheme ) {
+				return new WP_Error(
+					'oidc_discovery_insecure_endpoint',
+					sprintf(
+						/* translators: %s: discovery document field name */
+						__( 'Discovery document %s must use HTTPS. Set SECURE_OIDC_ALLOW_INSECURE_DISCOVERY=true to allow HTTP for testing.', 'secure-oidc-login' ),
+						$key
+					)
+				);
+			}
+		}
+
+		return true;
 	}
 }

--- a/includes/class-oidc-client.php
+++ b/includes/class-oidc-client.php
@@ -183,9 +183,10 @@ class OIDC_Client {
 				// client_secret_basic (default): credentials in Authorization header only.
 				// Per RFC 6749 section 2.3.1, clients using Basic auth MUST NOT include
 				// credentials in the request body, and the client_id and client_secret
-				// MUST each be form-urlencoded before being combined with a colon and
-				// base64-encoded. This matters for secrets containing ':', '%', '+', etc.
-				$credentials              = rawurlencode( $client_id ) . ':' . rawurlencode( $client_secret );
+				// MUST each be application/x-www-form-urlencoded (spaces become '+')
+				// before being combined with a colon and base64-encoded. This matters
+				// for secrets containing ':', '%', '+', or spaces.
+				$credentials              = urlencode( $client_id ) . ':' . urlencode( $client_secret );
 				$headers['Authorization'] = 'Basic ' . base64_encode( $credentials );
 			}
 		} else {
@@ -1086,7 +1087,9 @@ class OIDC_Client {
 
 		// Strip query string and fragment before comparing — some providers (e.g. Azure AD B2C)
 		// require query parameters on the discovery URL that are not part of the issuer.
-		$normalized_url = strtok( $discovery_url, '?#' );
+		// strcspn()+substr() is used instead of strtok() to avoid resetting PHP's
+		// shared tokeniser state for unrelated code in the same request.
+		$normalized_url = substr( $discovery_url, 0, strcspn( $discovery_url, '?#' ) );
 		$expected_url   = rtrim( $issuer, '/' ) . '/.well-known/openid-configuration';
 
 		if ( rtrim( (string) $normalized_url, '/' ) !== $expected_url ) {

--- a/includes/class-oidc-rest-controller.php
+++ b/includes/class-oidc-rest-controller.php
@@ -239,6 +239,18 @@ class OIDC_REST_Controller extends WP_REST_Controller {
 			);
 		}
 
+		// SECURITY: Verify the document's issuer matches the discovery URL (OIDC Discovery
+		// 1.0 Section 4.3) and that all advertised endpoints use HTTPS, before the
+		// configuration is offered to the admin form.
+		$validation = OIDC_Client::validate_discovery_document( $config, $discovery_url );
+		if ( is_wp_error( $validation ) ) {
+			return new WP_Error(
+				$validation->get_error_code(),
+				$validation->get_error_message(),
+				array( 'status' => 400 )
+			);
+		}
+
 		return new WP_REST_Response( $config, 200 );
 	}
 

--- a/includes/class-oidc-token-refresh.php
+++ b/includes/class-oidc-token-refresh.php
@@ -49,6 +49,16 @@ class OIDC_Token_Refresh {
 	const MAX_REFRESH_BUFFER = 3600;
 
 	/**
+	 * Lifetime of the per-user refresh lock in seconds.
+	 *
+	 * Long enough to cover the token endpoint round trip (10s timeout), short
+	 * enough that a failed refresh can be retried promptly without hammering the IdP.
+	 *
+	 * @var int
+	 */
+	const REFRESH_LOCK_TTL = 30;
+
+	/**
 	 * OIDC Client instance for token operations.
 	 *
 	 * @var OIDC_Client
@@ -116,6 +126,21 @@ class OIDC_Token_Refresh {
 	 * @return true|WP_Error True on success, WP_Error on failure.
 	 */
 	public function refresh( int $user_id ): bool|WP_Error {
+		// CONCURRENCY: Serialize refreshes per user. Parallel requests (multiple tabs,
+		// asset requests) would otherwise race: one request replays the old refresh
+		// token after another has rotated it, which rotation-enforcing IdPs treat as
+		// token reuse and may revoke the whole token family, logging the user out.
+		// The transient check-and-set is not strictly atomic, but it shrinks the race
+		// window from a full IdP round trip to microseconds. The lock is kept on
+		// failure so its TTL throttles retry storms against a struggling IdP.
+		$lock_key = 'oidc_refresh_lock_' . $user_id;
+		if ( false !== get_transient( $lock_key ) ) {
+			// Another request is refreshing (or just failed); treat as success so the
+			// current request proceeds with the still-valid stored token.
+			return true;
+		}
+		set_transient( $lock_key, 1, self::REFRESH_LOCK_TTL );
+
 		// Get the refresh token
 		$refresh_token = $this->token_manager->get_refresh_token( $user_id );
 		if ( is_wp_error( $refresh_token ) ) {
@@ -160,6 +185,9 @@ class OIDC_Token_Refresh {
 			$this->log_refresh_failure( $user_id, 'Failed to store refreshed tokens: ' . $store_result->get_error_message() );
 			return $store_result;
 		}
+
+		// Release the lock on success; the updated expiry prevents redundant refreshes.
+		delete_transient( $lock_key );
 
 		// Log success
 		$this->log_refresh_success( $user_id );

--- a/includes/class-oidc-token-refresh.php
+++ b/includes/class-oidc-token-refresh.php
@@ -59,6 +59,17 @@ class OIDC_Token_Refresh {
 	const REFRESH_LOCK_TTL = 30;
 
 	/**
+	 * Option-name prefix for the per-user refresh lock.
+	 *
+	 * Stored as a non-autoloaded option (not a transient) because add_option()
+	 * maps to INSERT IGNORE on the option_name unique key, giving an atomic
+	 * acquire across concurrent requests. Cleaned up on plugin deactivation.
+	 *
+	 * @var string
+	 */
+	const REFRESH_LOCK_PREFIX = 'oidc_refresh_lock_';
+
+	/**
 	 * OIDC Client instance for token operations.
 	 *
 	 * @var OIDC_Client
@@ -130,16 +141,11 @@ class OIDC_Token_Refresh {
 		// asset requests) would otherwise race: one request replays the old refresh
 		// token after another has rotated it, which rotation-enforcing IdPs treat as
 		// token reuse and may revoke the whole token family, logging the user out.
-		// The transient check-and-set is not strictly atomic, but it shrinks the race
-		// window from a full IdP round trip to microseconds. The lock is kept on
-		// failure so its TTL throttles retry storms against a struggling IdP.
-		$lock_key = 'oidc_refresh_lock_' . $user_id;
-		if ( false !== get_transient( $lock_key ) ) {
-			// Another request is refreshing (or just failed); treat as success so the
-			// current request proceeds with the still-valid stored token.
+		if ( ! $this->acquire_refresh_lock( $user_id ) ) {
+			// Another request is refreshing (or recently failed); treat as success so
+			// the current request proceeds with the still-valid stored token.
 			return true;
 		}
-		set_transient( $lock_key, 1, self::REFRESH_LOCK_TTL );
 
 		// Get the refresh token
 		$refresh_token = $this->token_manager->get_refresh_token( $user_id );
@@ -187,12 +193,57 @@ class OIDC_Token_Refresh {
 		}
 
 		// Release the lock on success; the updated expiry prevents redundant refreshes.
-		delete_transient( $lock_key );
+		$this->release_refresh_lock( $user_id );
 
 		// Log success
 		$this->log_refresh_success( $user_id );
 
 		return true;
+	}
+
+	/**
+	 * Atomically acquire the per-user refresh lock.
+	 *
+	 * CONCURRENCY: get_transient()+set_transient() is a non-atomic check-then-set,
+	 * so two requests could both miss the lock and both refresh. add_option() maps
+	 * to INSERT IGNORE on the option_name unique key, making the acquire atomic
+	 * across concurrent requests with or without a persistent object cache.
+	 *
+	 * The stored timestamp gives the lock a TTL: locks from crashed requests expire
+	 * after REFRESH_LOCK_TTL, and because the lock is only released on success, a
+	 * failed refresh leaves it in place so the TTL throttles retry storms against
+	 * a struggling IdP.
+	 *
+	 * @param int $user_id The WordPress user ID.
+	 * @return bool True if the lock was acquired, false if another request holds it.
+	 */
+	private function acquire_refresh_lock( int $user_id ): bool {
+		$lock_key = self::REFRESH_LOCK_PREFIX . $user_id;
+
+		if ( add_option( $lock_key, (string) time(), '', false ) ) {
+			return true;
+		}
+
+		$acquired_at = (int) get_option( $lock_key, 0 );
+		if ( time() - $acquired_at < self::REFRESH_LOCK_TTL ) {
+			return false;
+		}
+
+		// The existing lock is past its TTL (crashed request or failed refresh):
+		// clear it and retry the atomic acquire. If a concurrent request wins the
+		// add_option() race here, this request correctly backs off.
+		delete_option( $lock_key );
+		return add_option( $lock_key, (string) time(), '', false );
+	}
+
+	/**
+	 * Release the per-user refresh lock.
+	 *
+	 * @param int $user_id The WordPress user ID.
+	 * @return void
+	 */
+	private function release_refresh_lock( int $user_id ): void {
+		delete_option( self::REFRESH_LOCK_PREFIX . $user_id );
 	}
 
 	/**

--- a/secure-oidc-login.php
+++ b/secure-oidc-login.php
@@ -590,6 +590,29 @@ class Secure_OIDC_Login {
 		delete_transient( 'oidc_state_' . $state );
 		$this->clear_state_cookie();
 
+		$options = get_option( 'secure_oidc_login_settings' );
+		if ( ! is_array( $options ) ) {
+			$options = array();
+		}
+
+		// SECURITY: Validate the RFC 9207 `iss` authorization response parameter before
+		// processing the response. This defends against IdP mix-up attacks: a response
+		// carrying a different issuer is rejected before the authorization code is used.
+		// If the IdP advertised authorization_response_iss_parameter_supported during
+		// discovery, the parameter is required on every response.
+		$expected_issuer = self::get_setting( 'issuer', $options );
+		$response_iss    = isset( $_GET['iss'] ) ? sanitize_text_field( wp_unslash( $_GET['iss'] ) ) : '';
+
+		if ( '' !== $response_iss ) {
+			if ( empty( $expected_issuer ) || $response_iss !== $expected_issuer ) {
+				$this->handle_error( __( 'Authorization response issuer does not match the configured identity provider.', 'secure-oidc-login' ) );
+				return;
+			}
+		} elseif ( ! empty( $options['authorization_response_iss_parameter_supported'] ) ) {
+			$this->handle_error( __( 'Missing iss parameter in authorization response.', 'secure-oidc-login' ) );
+			return;
+		}
+
 		// Check for errors returned by the IdP
 		if ( ! empty( $_GET['error'] ) ) {
 			// Keep if-then for nested condition clarity
@@ -633,9 +656,6 @@ class Secure_OIDC_Login {
 
 		// Delete nonce to prevent replay attacks
 		delete_transient( 'oidc_nonce_' . $state );
-
-		// Get plugin options for ACR validation and token storage
-		$options = get_option( 'secure_oidc_login_settings' );
 
 		// Validate ACR claim if enforcement is enabled
 		$acr_result = $this->client->validate_acr_claim( $id_token_claims, $options );
@@ -697,9 +717,22 @@ class Secure_OIDC_Login {
 		$this->rate_limiter->clear_limit( 'callback' );
 		$this->rate_limiter->clear_limit( 'login' );
 
-		// Establish WordPress session
+		// Establish WordPress session. "Remember" controls the auth cookie lifetime:
+		// enabled (default) gives WordPress's 14-day persistent cookie, disabled gives
+		// a session cookie that aligns the WP session more closely with the IdP session.
+		$remember = ! isset( $options['remember_user'] ) || ! empty( $options['remember_user'] );
+
+		/**
+		 * Filter whether the OIDC login should set a persistent ("remember me") auth cookie.
+		 *
+		 * @param bool                 $remember        Whether to set a persistent cookie.
+		 * @param WP_User              $user            The user being logged in.
+		 * @param array<string, mixed> $id_token_claims Validated ID token claims.
+		 */
+		$remember = (bool) apply_filters( 'secure_oidc_login_remember_user', $remember, $user, $id_token_claims );
+
 		wp_set_current_user( $user->ID );
-		wp_set_auth_cookie( $user->ID, true );
+		wp_set_auth_cookie( $user->ID, $remember );
 		do_action( 'wp_login', $user->user_login, $user );
 
 		// Redirect to requested page or admin dashboard
@@ -768,6 +801,13 @@ class Secure_OIDC_Login {
 				'id_token_hint'            => $id_token,
 				'post_logout_redirect_uri' => home_url(),
 			);
+
+			// Per OIDC RP-Initiated Logout 1.0 section 2, client_id lets the IdP
+			// validate post_logout_redirect_uri even when it cannot use id_token_hint.
+			$client_id = self::get_setting( 'client_id', $options );
+			if ( ! empty( $client_id ) ) {
+				$logout_params['client_id'] = $client_id;
+			}
 
 			$logout_url = $end_session_endpoint . '?' . http_build_query( $logout_params );
 
@@ -977,6 +1017,8 @@ class Secure_OIDC_Login {
 			'login_button_text'                     => 'Login with SSO',
 			'enable_single_logout'                  => false,
 			'disable_native_login'                  => false,
+			'remember_user'                         => true,
+			'authorization_response_iss_parameter_supported' => false,
 			'enable_auto_token_refresh'             => false,
 			'token_refresh_buffer'                  => 300,
 			'enforce_refresh_token_rotation'        => false,

--- a/secure-oidc-login.php
+++ b/secure-oidc-login.php
@@ -600,8 +600,14 @@ class Secure_OIDC_Login {
 		// carrying a different issuer is rejected before the authorization code is used.
 		// If the IdP advertised authorization_response_iss_parameter_supported during
 		// discovery, the parameter is required on every response.
+		// The raw (unslashed) value is compared: sanitize_text_field() strips %XX
+		// sequences, which would corrupt percent-encoded issuer URLs and make valid
+		// callbacks fail the strict equality check. The value is only compared,
+		// never stored or output.
 		$expected_issuer = self::get_setting( 'issuer', $options );
-		$response_iss    = isset( $_GET['iss'] ) ? sanitize_text_field( wp_unslash( $_GET['iss'] ) ) : '';
+		$response_iss    = isset( $_GET['iss'] ) && is_string( $_GET['iss'] )
+			? wp_unslash( $_GET['iss'] ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Strict comparison only; never persisted or output.
+			: '';
 
 		if ( '' !== $response_iss ) {
 			if ( empty( $expected_issuer ) || $response_iss !== $expected_issuer ) {
@@ -1039,15 +1045,16 @@ class Secure_OIDC_Login {
 	}
 
 	/**
-	 * Plugin deactivation hook. Cleans up OIDC-related transients.
+	 * Plugin deactivation hook. Cleans up OIDC-related transients and refresh locks.
 	 */
 	public function deactivate(): void {
 		global $wpdb;
 		$wpdb->query(
 			$wpdb->prepare(
-				"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s",
+				"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s OR option_name LIKE %s",
 				$wpdb->esc_like( '_transient_oidc_' ) . '%',
-				$wpdb->esc_like( '_transient_timeout_oidc_' ) . '%'
+				$wpdb->esc_like( '_transient_timeout_oidc_' ) . '%',
+				$wpdb->esc_like( OIDC_Token_Refresh::REFRESH_LOCK_PREFIX ) . '%'
 			)
 		);
 	}

--- a/tests/Unit/Admin/OIDCAdminTest.php
+++ b/tests/Unit/Admin/OIDCAdminTest.php
@@ -1759,4 +1759,87 @@ class OIDCAdminTest extends OIDCTestCase
             $this->assertStringContainsString($needle, $output, "{$method} should render its description text");
         }
     }
+
+    // =========================================================================
+    // RFC 9207 iss Parameter Support Flag Tests
+    // =========================================================================
+
+    /**
+     * Test sanitize_settings stores the iss-support flag from a fresh discovery.
+     */
+    public function testSanitizeSettingsSetsIssFlagFromDiscovery(): void
+    {
+        Functions\when('get_option')->justReturn([
+            'issuer' => 'https://old-idp.example.com',
+            'authorization_response_iss_parameter_supported' => false,
+        ]);
+        Functions\when('current_user_can')->justReturn(true);
+        Functions\when('wp_verify_nonce')->justReturn(true);
+
+        $_POST['_wpnonce'] = 'valid-nonce';
+
+        // Discovery ran on this submission: issuer and flag submitted together
+        $input = [
+            'issuer' => 'https://new-idp.example.com',
+            'authorization_response_iss_parameter_supported' => '1',
+        ];
+
+        $result = $this->admin->sanitize_settings($input);
+
+        $this->assertTrue($result['authorization_response_iss_parameter_supported']);
+    }
+
+    /**
+     * Test sanitize_settings clears the iss-support flag when the issuer changes
+     * without a fresh discovery.
+     *
+     * The flag was discovered for a specific provider; carrying it over to a new
+     * issuer could hard-break login against an IdP that never sends iss.
+     */
+    public function testSanitizeSettingsClearsIssFlagWhenIssuerChangesWithoutDiscovery(): void
+    {
+        Functions\when('get_option')->justReturn([
+            'issuer' => 'https://old-idp.example.com',
+            'authorization_response_iss_parameter_supported' => true,
+        ]);
+        Functions\when('current_user_can')->justReturn(true);
+        Functions\when('wp_verify_nonce')->justReturn(true);
+
+        $_POST['_wpnonce'] = 'valid-nonce';
+
+        // Issuer manually changed; hidden iss field is empty (no discovery run)
+        $input = [
+            'issuer' => 'https://new-idp.example.com',
+            'authorization_response_iss_parameter_supported' => '',
+        ];
+
+        $result = $this->admin->sanitize_settings($input);
+
+        $this->assertFalse($result['authorization_response_iss_parameter_supported']);
+    }
+
+    /**
+     * Test sanitize_settings preserves the iss-support flag when the issuer is unchanged.
+     */
+    public function testSanitizeSettingsPreservesIssFlagWhenIssuerUnchanged(): void
+    {
+        Functions\when('get_option')->justReturn([
+            'issuer' => 'https://idp.example.com',
+            'authorization_response_iss_parameter_supported' => true,
+        ]);
+        Functions\when('current_user_can')->justReturn(true);
+        Functions\when('wp_verify_nonce')->justReturn(true);
+
+        $_POST['_wpnonce'] = 'valid-nonce';
+
+        // Normal settings save: same issuer, hidden iss field empty
+        $input = [
+            'issuer' => 'https://idp.example.com',
+            'authorization_response_iss_parameter_supported' => '',
+        ];
+
+        $result = $this->admin->sanitize_settings($input);
+
+        $this->assertTrue($result['authorization_response_iss_parameter_supported']);
+    }
 }

--- a/tests/Unit/Client/OIDCClientTest.php
+++ b/tests/Unit/Client/OIDCClientTest.php
@@ -58,6 +58,7 @@ class OIDCClientTest extends OIDCTestCase
             'wp_remote_retrieve_body' => static fn($response) => $response['body'] ?? '',
             'wp_remote_retrieve_header' => static fn($response, $header) => 'application/json',
             'wp_strip_all_tags' => static fn($string) => strip_tags($string),
+            'wp_parse_url' => static fn($url, $component = -1) => parse_url($url, $component),
             'get_transient' => static fn($key) => false,
             'set_transient' => static fn($key, $value, $expiration) => true,
             'delete_transient' => static fn($key) => true,
@@ -2592,5 +2593,302 @@ class OIDCClientTest extends OIDCTestCase
         // Should proceed past algorithm checks (fail on signature/key, not algorithm)
         $this->assertInstanceOf(WP_Error::class, $result);
         $this->assertStringNotContainsString('algorithm', strtolower($result->get_error_message()));
+    }
+
+    // =========================================================================
+    // Discovery Document Validation Tests (OIDC Discovery 1.0 Section 4.3)
+    // =========================================================================
+
+    /**
+     * Test validate_discovery_document accepts a document whose issuer matches the URL.
+     */
+    public function testValidateDiscoveryDocumentAcceptsMatchingIssuer(): void
+    {
+        putenv('SECURE_OIDC_ALLOW_INSECURE_DISCOVERY');
+
+        $result = OIDC_Client::validate_discovery_document(
+            $this->getSampleOIDCConfig(),
+            'https://idp.example.com/.well-known/openid-configuration'
+        );
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test validate_discovery_document rejects a document with a mismatched issuer.
+     */
+    public function testValidateDiscoveryDocumentRejectsIssuerMismatch(): void
+    {
+        putenv('SECURE_OIDC_ALLOW_INSECURE_DISCOVERY');
+
+        $config = $this->getSampleOIDCConfig();
+        $config['issuer'] = 'https://evil.example.org';
+
+        $result = OIDC_Client::validate_discovery_document(
+            $config,
+            'https://idp.example.com/.well-known/openid-configuration'
+        );
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('oidc_discovery_issuer_mismatch', $result->get_error_code());
+    }
+
+    /**
+     * Test validate_discovery_document rejects a document without an issuer.
+     */
+    public function testValidateDiscoveryDocumentRejectsMissingIssuer(): void
+    {
+        $config = $this->getSampleOIDCConfig();
+        unset($config['issuer']);
+
+        $result = OIDC_Client::validate_discovery_document(
+            $config,
+            'https://idp.example.com/.well-known/openid-configuration'
+        );
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('oidc_discovery_missing_issuer', $result->get_error_code());
+    }
+
+    /**
+     * Test validate_discovery_document tolerates a trailing slash on the issuer.
+     */
+    public function testValidateDiscoveryDocumentToleratesTrailingSlashOnIssuer(): void
+    {
+        putenv('SECURE_OIDC_ALLOW_INSECURE_DISCOVERY');
+
+        $config = $this->getSampleOIDCConfig();
+        $config['issuer'] = 'https://idp.example.com/';
+
+        $result = OIDC_Client::validate_discovery_document(
+            $config,
+            'https://idp.example.com/.well-known/openid-configuration'
+        );
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test validate_discovery_document ignores query strings on the discovery URL.
+     *
+     * Some providers (e.g. Azure AD B2C) require query parameters on the
+     * discovery URL that are not part of the issuer identifier.
+     */
+    public function testValidateDiscoveryDocumentIgnoresQueryStringOnDiscoveryUrl(): void
+    {
+        putenv('SECURE_OIDC_ALLOW_INSECURE_DISCOVERY');
+
+        $result = OIDC_Client::validate_discovery_document(
+            $this->getSampleOIDCConfig(),
+            'https://idp.example.com/.well-known/openid-configuration?p=policy_name'
+        );
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test validate_discovery_document rejects non-HTTPS endpoints by default.
+     */
+    public function testValidateDiscoveryDocumentRejectsHttpEndpoint(): void
+    {
+        putenv('SECURE_OIDC_ALLOW_INSECURE_DISCOVERY');
+
+        $config = $this->getSampleOIDCConfig();
+        $config['token_endpoint'] = 'http://idp.example.com/token';
+
+        $result = OIDC_Client::validate_discovery_document(
+            $config,
+            'https://idp.example.com/.well-known/openid-configuration'
+        );
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('oidc_discovery_insecure_endpoint', $result->get_error_code());
+    }
+
+    /**
+     * Test validate_discovery_document allows HTTP endpoints with the testing escape hatch.
+     */
+    public function testValidateDiscoveryDocumentAllowsHttpEndpointWhenInsecureAllowed(): void
+    {
+        putenv('SECURE_OIDC_ALLOW_INSECURE_DISCOVERY=true');
+
+        try {
+            $config = $this->getSampleOIDCConfig();
+            $config['token_endpoint'] = 'http://idp.example.com/token';
+
+            $result = OIDC_Client::validate_discovery_document(
+                $config,
+                'https://idp.example.com/.well-known/openid-configuration'
+            );
+
+            $this->assertTrue($result);
+        } finally {
+            putenv('SECURE_OIDC_ALLOW_INSECURE_DISCOVERY');
+        }
+    }
+
+    /**
+     * Test validate_discovery_document rejects malformed endpoint URLs.
+     */
+    public function testValidateDiscoveryDocumentRejectsMalformedEndpoint(): void
+    {
+        $config = $this->getSampleOIDCConfig();
+        $config['jwks_uri'] = 'not a url';
+
+        $result = OIDC_Client::validate_discovery_document(
+            $config,
+            'https://idp.example.com/.well-known/openid-configuration'
+        );
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('oidc_discovery_invalid_endpoint', $result->get_error_code());
+    }
+
+    /**
+     * Test discover() rejects a discovery document whose issuer does not match.
+     */
+    public function testDiscoverRejectsMismatchedIssuer(): void
+    {
+        putenv('SECURE_OIDC_ALLOW_INSECURE_DISCOVERY');
+
+        $config = $this->getSampleOIDCConfig();
+        $config['issuer'] = 'https://other-idp.example.net';
+
+        Functions\when('wp_safe_remote_get')->justReturn([
+            'body' => json_encode($config),
+            'response' => ['code' => 200]
+        ]);
+
+        $result = $this->client->discover('https://idp.example.com');
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('oidc_discovery_issuer_mismatch', $result->get_error_code());
+    }
+
+    // =========================================================================
+    // Refresh Token Response Validation Tests (RFC 6749 Section 5.1)
+    // =========================================================================
+
+    /**
+     * Test refresh_token returns error when access_token is missing.
+     */
+    public function testRefreshTokenReturnsErrorWhenAccessTokenMissing(): void
+    {
+        Functions\when('wp_safe_remote_post')->justReturn([
+            'body' => '{"token_type": "Bearer", "expires_in": 3600}',
+            'response' => ['code' => 200]
+        ]);
+
+        $result = $this->client->refresh_token('refresh-token-value');
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertStringContainsString('Invalid token response', $result->get_error_message());
+    }
+
+    /**
+     * Test refresh_token returns error when token_type is missing.
+     */
+    public function testRefreshTokenReturnsErrorWhenTokenTypeMissing(): void
+    {
+        Functions\when('wp_safe_remote_post')->justReturn([
+            'body' => '{"access_token": "new-access-token", "expires_in": 3600}',
+            'response' => ['code' => 200]
+        ]);
+
+        $result = $this->client->refresh_token('refresh-token-value');
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertStringContainsString('Missing required token_type', $result->get_error_message());
+    }
+
+    /**
+     * Test refresh_token returns error for non-Bearer token type.
+     */
+    public function testRefreshTokenReturnsErrorForUnsupportedTokenType(): void
+    {
+        Functions\when('wp_safe_remote_post')->justReturn([
+            'body' => '{"access_token": "new-access-token", "token_type": "MAC"}',
+            'response' => ['code' => 200]
+        ]);
+
+        $result = $this->client->refresh_token('refresh-token-value');
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertStringContainsString('Unsupported token type', $result->get_error_message());
+    }
+
+    // =========================================================================
+    // Client Authentication Encoding Tests (RFC 6749 Section 2.3.1)
+    // =========================================================================
+
+    /**
+     * Test Basic auth credentials are form-urlencoded before base64 encoding.
+     *
+     * Per RFC 6749 section 2.3.1 the client_id and client_secret must each be
+     * urlencoded before being combined with a colon, so secrets containing
+     * reserved characters (':', '%', '+') round-trip correctly.
+     */
+    public function testBasicAuthCredentialsAreFormUrlencoded(): void
+    {
+        Functions\when('get_option')->justReturn([
+            'client_id' => 'client:with:colons',
+            'client_secret' => 'secret%with+special:chars',
+            'token_endpoint' => 'https://idp.example.com/token',
+        ]);
+
+        $client = new OIDC_Client();
+        $headers = null;
+
+        Functions\when('wp_safe_remote_post')->alias(function($url, $args) use (&$headers) {
+            $headers = $args['headers'] ?? [];
+            return [
+                'body' => json_encode([
+                    'access_token' => 'test-access',
+                    'id_token' => 'test-id',
+                    'token_type' => 'Bearer'
+                ]),
+                'response' => ['code' => 200]
+            ];
+        });
+
+        $client->exchange_code('auth-code');
+
+        $this->assertArrayHasKey('Authorization', $headers);
+        $decoded = base64_decode(substr($headers['Authorization'], strlen('Basic ')));
+        $this->assertSame(
+            rawurlencode('client:with:colons') . ':' . rawurlencode('secret%with+special:chars'),
+            $decoded
+        );
+    }
+
+    /**
+     * Test JWKS keys with an unknown kty and no alg are skipped, not assigned the header alg.
+     */
+    public function testDecodeAndVerifyJwtSkipsKeysWithUnknownKty(): void
+    {
+        // Single key with unrecognized kty and no alg field - must be dropped
+        $jwks = ['keys' => [
+            ['kty' => 'UNKNOWN', 'kid' => 'test-key', 'n' => 'modulus', 'e' => 'AQAB'],
+        ]];
+
+        Functions\when('get_transient')->justReturn(false);
+        Functions\when('wp_safe_remote_get')->justReturn([
+            'body' => json_encode($jwks),
+            'response' => ['code' => 200],
+        ]);
+        Functions\when('set_transient')->justReturn(true);
+        Functions\when('wp_json_encode')->alias(fn($data) => json_encode($data));
+
+        $reflection = new \ReflectionMethod(OIDC_Client::class, 'decode_and_verify_jwt');
+        $reflection->setAccessible(true);
+
+        $header = rtrim(strtr(base64_encode(json_encode(['alg' => 'RS256', 'typ' => 'JWT'])), '+/', '-_'), '=');
+        $payload = rtrim(strtr(base64_encode('{"sub":"test"}'), '+/', '-_'), '=');
+        $signature = rtrim(strtr(base64_encode('fake-sig'), '+/', '-_'), '=');
+
+        $result = $reflection->invoke($this->client, "$header.$payload.$signature");
+
+        // With the only key dropped, the key set is empty and verification must fail
+        $this->assertInstanceOf(WP_Error::class, $result);
     }
 }

--- a/tests/Unit/Client/OIDCClientTest.php
+++ b/tests/Unit/Client/OIDCClientTest.php
@@ -2825,14 +2825,15 @@ class OIDCClientTest extends OIDCTestCase
      * Test Basic auth credentials are form-urlencoded before base64 encoding.
      *
      * Per RFC 6749 section 2.3.1 the client_id and client_secret must each be
-     * urlencoded before being combined with a colon, so secrets containing
-     * reserved characters (':', '%', '+') round-trip correctly.
+     * application/x-www-form-urlencoded (spaces become '+') before being combined
+     * with a colon, so secrets containing reserved characters (':', '%', '+', ' ')
+     * round-trip correctly.
      */
     public function testBasicAuthCredentialsAreFormUrlencoded(): void
     {
         Functions\when('get_option')->justReturn([
             'client_id' => 'client:with:colons',
-            'client_secret' => 'secret%with+special:chars',
+            'client_secret' => 'secret%with+special:chars and spaces',
             'token_endpoint' => 'https://idp.example.com/token',
         ]);
 
@@ -2856,7 +2857,7 @@ class OIDCClientTest extends OIDCTestCase
         $this->assertArrayHasKey('Authorization', $headers);
         $decoded = base64_decode(substr($headers['Authorization'], strlen('Basic ')));
         $this->assertSame(
-            rawurlencode('client:with:colons') . ':' . rawurlencode('secret%with+special:chars'),
+            'client%3Awith%3Acolons:secret%25with%2Bspecial%3Achars+and+spaces',
             $decoded
         );
     }

--- a/tests/Unit/REST/OIDCRestControllerTest.php
+++ b/tests/Unit/REST/OIDCRestControllerTest.php
@@ -904,7 +904,7 @@ class OIDCRestControllerTest extends OIDCTestCase
     }
 
     /**
-     * Test discover handles JSON array instead of object.
+     * Test discover rejects a JSON array - a list is not a provider configuration.
      */
     public function testDiscoverHandlesJsonArrayInsteadOfObject(): void
     {
@@ -923,8 +923,64 @@ class OIDCRestControllerTest extends OIDCTestCase
 
         $result = $this->controller->discover($request);
 
-        // JSON array should be valid - it's an array in PHP
-        $this->assertInstanceOf(WP_REST_Response::class, $result);
+        // A JSON list has no issuer, so document validation must reject it
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('oidc_discovery_missing_issuer', $result->get_error_code());
+    }
+
+    /**
+     * Test discover rejects a document whose issuer does not match the discovery URL.
+     *
+     * Per OIDC Discovery 1.0 Section 4.3 the issuer must equal the discovery URL
+     * with the well-known suffix removed; accepting a mismatched document would
+     * configure this client against a different provider's endpoints.
+     */
+    public function testDiscoverRejectsIssuerMismatch(): void
+    {
+        Functions\when('wp_http_validate_url')->alias(fn($url) => $url);
+
+        $config = $this->getSampleOIDCConfig();
+        $config['issuer'] = 'https://other-idp.example.net';
+
+        Functions\when('wp_safe_remote_get')->justReturn([
+            'body' => json_encode($config),
+            'response' => ['code' => 200],
+        ]);
+        Functions\when('wp_remote_retrieve_header')->justReturn('application/json');
+
+        $request = $this->createMock(WP_REST_Request::class);
+        $request->method('get_param')->willReturn('https://idp.example.com');
+
+        $result = $this->controller->discover($request);
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('oidc_discovery_issuer_mismatch', $result->get_error_code());
+        $this->assertSame(400, $result->get_error_data()['status'] ?? null);
+    }
+
+    /**
+     * Test discover rejects a document advertising a non-HTTPS endpoint.
+     */
+    public function testDiscoverRejectsInsecureEndpoint(): void
+    {
+        Functions\when('wp_http_validate_url')->alias(fn($url) => $url);
+
+        $config = $this->getSampleOIDCConfig();
+        $config['token_endpoint'] = 'http://idp.example.com/token';
+
+        Functions\when('wp_safe_remote_get')->justReturn([
+            'body' => json_encode($config),
+            'response' => ['code' => 200],
+        ]);
+        Functions\when('wp_remote_retrieve_header')->justReturn('application/json');
+
+        $request = $this->createMock(WP_REST_Request::class);
+        $request->method('get_param')->willReturn('https://idp.example.com');
+
+        $result = $this->controller->discover($request);
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('oidc_discovery_insecure_endpoint', $result->get_error_code());
     }
 
     /**

--- a/tests/Unit/Token/OIDCTokenRefreshTest.php
+++ b/tests/Unit/Token/OIDCTokenRefreshTest.php
@@ -55,6 +55,11 @@ class OIDCTokenRefreshTest extends OIDCTestCase
         // Stub wp_salt for encryption
         Functions\when('wp_salt')->justReturn('test-salt-value-for-unit-testing');
 
+        // Stub transients used by the per-user refresh lock (no lock held by default)
+        Functions\when('get_transient')->justReturn(false);
+        Functions\when('set_transient')->justReturn(true);
+        Functions\when('delete_transient')->justReturn(true);
+
         $this->client = Mockery::mock(OIDC_Client::class);
         $this->token_manager = Mockery::mock(OIDC_Token_Manager::class);
 
@@ -1445,5 +1450,128 @@ class OIDCTokenRefreshTest extends OIDCTestCase
 
         $this->assertInstanceOf(WP_Error::class, $result);
         $this->assertSame('oidc_refresh_id_token_invalid', $result->get_error_code());
+    }
+
+    // =========================================================================
+    // Refresh Concurrency Lock Tests
+    // =========================================================================
+
+    /**
+     * Test refresh is skipped when another request holds the per-user lock.
+     *
+     * Prevents parallel requests from racing the refresh: with rotation-enforcing
+     * IdPs, replaying the old refresh token after rotation can revoke the whole
+     * token family and log the user out.
+     */
+    public function testRefreshSkipsWhenLockHeld(): void
+    {
+        $user_id = 123;
+
+        Functions\when('get_option')->justReturn([]);
+
+        // Lock transient is already set by a concurrent request
+        Functions\when('get_transient')->alias(
+            static fn($key) => 'oidc_refresh_lock_123' === $key ? 1 : false
+        );
+
+        // No IdP call and no token reads should happen
+        $this->token_manager->shouldNotReceive('get_refresh_token');
+        $this->client->shouldNotReceive('refresh_token');
+
+        $result = $this->refresh->refresh($user_id);
+
+        // Treated as success: the concurrent request is handling the refresh
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test refresh acquires the lock and releases it on success.
+     */
+    public function testRefreshAcquiresAndReleasesLockOnSuccess(): void
+    {
+        $user_id = 123;
+        $set_keys = [];
+        $deleted_keys = [];
+
+        Functions\when('get_option')->justReturn([
+            'enforce_refresh_token_rotation' => false,
+        ]);
+
+        Functions\when('set_transient')->alias(function ($key, $value, $ttl) use (&$set_keys) {
+            $set_keys[] = $key;
+            return true;
+        });
+        Functions\when('delete_transient')->alias(function ($key) use (&$deleted_keys) {
+            $deleted_keys[] = $key;
+            return true;
+        });
+
+        $new_tokens = [
+            'access_token' => 'new-access-token',
+            'refresh_token' => 'new-refresh-token',
+            'expires_in' => 3600,
+        ];
+
+        $this->token_manager
+            ->shouldReceive('get_refresh_token')
+            ->with($user_id)
+            ->once()
+            ->andReturn('old-refresh-token');
+
+        $this->client
+            ->shouldReceive('refresh_token')
+            ->with('old-refresh-token')
+            ->once()
+            ->andReturn($new_tokens);
+
+        $this->token_manager
+            ->shouldReceive('was_refresh_token_rotated')
+            ->with($user_id, 'new-refresh-token')
+            ->once()
+            ->andReturn(true);
+
+        $this->token_manager
+            ->shouldReceive('store_tokens')
+            ->with($user_id, $new_tokens)
+            ->once()
+            ->andReturn(true);
+
+        $result = $this->refresh->refresh($user_id);
+
+        $this->assertTrue($result);
+        $this->assertContains('oidc_refresh_lock_123', $set_keys);
+        $this->assertContains('oidc_refresh_lock_123', $deleted_keys);
+    }
+
+    /**
+     * Test the lock is kept on failure so its TTL throttles retry storms.
+     */
+    public function testRefreshKeepsLockOnFailure(): void
+    {
+        $user_id = 123;
+        $deleted_keys = [];
+
+        Functions\when('get_option')->justReturn([]);
+        Functions\when('delete_transient')->alias(function ($key) use (&$deleted_keys) {
+            $deleted_keys[] = $key;
+            return true;
+        });
+
+        $this->token_manager
+            ->shouldReceive('get_refresh_token')
+            ->with($user_id)
+            ->once()
+            ->andReturn('old-refresh-token');
+
+        $this->client
+            ->shouldReceive('refresh_token')
+            ->with('old-refresh-token')
+            ->once()
+            ->andReturn(new WP_Error('oidc_error', 'IdP temporarily unavailable'));
+
+        $result = $this->refresh->refresh($user_id);
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertNotContains('oidc_refresh_lock_123', $deleted_keys);
     }
 }

--- a/tests/Unit/Token/OIDCTokenRefreshTest.php
+++ b/tests/Unit/Token/OIDCTokenRefreshTest.php
@@ -55,10 +55,10 @@ class OIDCTokenRefreshTest extends OIDCTestCase
         // Stub wp_salt for encryption
         Functions\when('wp_salt')->justReturn('test-salt-value-for-unit-testing');
 
-        // Stub transients used by the per-user refresh lock (no lock held by default)
-        Functions\when('get_transient')->justReturn(false);
-        Functions\when('set_transient')->justReturn(true);
-        Functions\when('delete_transient')->justReturn(true);
+        // Stub the option functions backing the per-user refresh lock
+        // (add_option succeeding means no lock is held by default)
+        Functions\when('add_option')->justReturn(true);
+        Functions\when('delete_option')->justReturn(true);
 
         $this->client = Mockery::mock(OIDC_Client::class);
         $this->token_manager = Mockery::mock(OIDC_Token_Manager::class);
@@ -778,6 +778,11 @@ class OIDCTokenRefreshTest extends OIDCTestCase
 
     /**
      * Test refresh after previous refresh failure recovers correctly.
+     *
+     * The default add_option() stub always grants the lock, modeling a retry
+     * after the failure lock's TTL has elapsed. Immediate-retry suppression
+     * while the lock is held is covered by testRefreshSkipsWhenLockHeld and
+     * testRefreshKeepsLockOnFailure.
      */
     public function testRefreshAfterPreviousFailureRecovers(): void
     {
@@ -1467,11 +1472,12 @@ class OIDCTokenRefreshTest extends OIDCTestCase
     {
         $user_id = 123;
 
-        Functions\when('get_option')->justReturn([]);
+        // add_option() fails atomically because a concurrent request holds the lock
+        Functions\when('add_option')->justReturn(false);
 
-        // Lock transient is already set by a concurrent request
-        Functions\when('get_transient')->alias(
-            static fn($key) => 'oidc_refresh_lock_123' === $key ? 1 : false
+        // The lock timestamp is recent (within REFRESH_LOCK_TTL)
+        Functions\when('get_option')->alias(
+            static fn($key, $default = false) => 'oidc_refresh_lock_123' === $key ? (string) time() : []
         );
 
         // No IdP call and no token reads should happen
@@ -1485,23 +1491,32 @@ class OIDCTokenRefreshTest extends OIDCTestCase
     }
 
     /**
-     * Test refresh acquires the lock and releases it on success.
+     * Test refresh takes over a lock whose TTL has expired (crashed request).
      */
-    public function testRefreshAcquiresAndReleasesLockOnSuccess(): void
+    public function testRefreshTakesOverStaleLock(): void
     {
         $user_id = 123;
-        $set_keys = [];
+        $add_calls = 0;
         $deleted_keys = [];
 
-        Functions\when('get_option')->justReturn([
-            'enforce_refresh_token_rotation' => false,
-        ]);
-
-        Functions\when('set_transient')->alias(function ($key, $value, $ttl) use (&$set_keys) {
-            $set_keys[] = $key;
-            return true;
+        // First add_option() fails (stale lock row exists); after the stale lock
+        // is deleted, the retried add_option() succeeds.
+        Functions\when('add_option')->alias(function ($key) use (&$add_calls) {
+            $add_calls++;
+            return 1 !== $add_calls;
         });
-        Functions\when('delete_transient')->alias(function ($key) use (&$deleted_keys) {
+
+        // The lock timestamp is older than REFRESH_LOCK_TTL
+        Functions\when('get_option')->alias(
+            static function ($key, $default = false) {
+                if ('oidc_refresh_lock_123' === $key) {
+                    return (string) (time() - OIDC_Token_Refresh::REFRESH_LOCK_TTL - 10);
+                }
+                return ['enforce_refresh_token_rotation' => false];
+            }
+        );
+
+        Functions\when('delete_option')->alias(function ($key) use (&$deleted_keys) {
             $deleted_keys[] = $key;
             return true;
         });
@@ -1539,7 +1554,67 @@ class OIDCTokenRefreshTest extends OIDCTestCase
         $result = $this->refresh->refresh($user_id);
 
         $this->assertTrue($result);
-        $this->assertContains('oidc_refresh_lock_123', $set_keys);
+        // Stale lock deleted before re-acquire, then released after success
+        $this->assertSame(2, $add_calls);
+        $this->assertContains('oidc_refresh_lock_123', $deleted_keys);
+    }
+
+    /**
+     * Test refresh acquires the lock and releases it on success.
+     */
+    public function testRefreshAcquiresAndReleasesLockOnSuccess(): void
+    {
+        $user_id = 123;
+        $added_keys = [];
+        $deleted_keys = [];
+
+        Functions\when('get_option')->justReturn([
+            'enforce_refresh_token_rotation' => false,
+        ]);
+
+        Functions\when('add_option')->alias(function ($key) use (&$added_keys) {
+            $added_keys[] = $key;
+            return true;
+        });
+        Functions\when('delete_option')->alias(function ($key) use (&$deleted_keys) {
+            $deleted_keys[] = $key;
+            return true;
+        });
+
+        $new_tokens = [
+            'access_token' => 'new-access-token',
+            'refresh_token' => 'new-refresh-token',
+            'expires_in' => 3600,
+        ];
+
+        $this->token_manager
+            ->shouldReceive('get_refresh_token')
+            ->with($user_id)
+            ->once()
+            ->andReturn('old-refresh-token');
+
+        $this->client
+            ->shouldReceive('refresh_token')
+            ->with('old-refresh-token')
+            ->once()
+            ->andReturn($new_tokens);
+
+        $this->token_manager
+            ->shouldReceive('was_refresh_token_rotated')
+            ->with($user_id, 'new-refresh-token')
+            ->once()
+            ->andReturn(true);
+
+        $this->token_manager
+            ->shouldReceive('store_tokens')
+            ->with($user_id, $new_tokens)
+            ->once()
+            ->andReturn(true);
+
+        $result = $this->refresh->refresh($user_id);
+
+        $this->assertTrue($result);
+        $this->assertContains('oidc_refresh_lock_123', $added_keys);
         $this->assertContains('oidc_refresh_lock_123', $deleted_keys);
     }
 
@@ -1552,7 +1627,7 @@ class OIDCTokenRefreshTest extends OIDCTestCase
         $deleted_keys = [];
 
         Functions\when('get_option')->justReturn([]);
-        Functions\when('delete_transient')->alias(function ($key) use (&$deleted_keys) {
+        Functions\when('delete_option')->alias(function ($key) use (&$deleted_keys) {
             $deleted_keys[] = $key;
             return true;
         });


### PR DESCRIPTION
## Summary

Follow-up to a security review of the OIDC authentication flow. The review found **no critical vulnerabilities** — this PR closes the remaining spec-compliance gaps and fixes one real reliability bug.

### Security

- **Discovery issuer validation (OIDC Discovery 1.0 §4.3)** — the discovery document's `issuer` must now match the discovery URL (well-known suffix stripped, query string tolerated for providers like Azure AD B2C), and all advertised endpoints must use HTTPS unless `SECURE_OIDC_ALLOW_INSECURE_DISCOVERY=true`. Enforced in both the REST discovery endpoint and `OIDC_Client::discover()` via a shared `validate_discovery_document()` helper. Previously any document was accepted, which is the precondition for IdP mix-up attacks.
- **RFC 9207 `iss` authorization response parameter** — the callback validates `iss` against the configured issuer before the authorization code is used, and requires the parameter when the IdP advertised `authorization_response_iss_parameter_supported` during discovery (recorded via a new hidden setting populated by the Discover button).
- **RFC 6749 §2.3.1 Basic-auth encoding** — `client_id`/`client_secret` are form-urlencoded before base64 encoding, fixing interop with secrets containing `:`, `%`, `+`. The duplicated client-auth blocks in `exchange_code()` and `refresh_token()` are consolidated into `apply_client_authentication()`.
- **JWKS hardening** — keys with an unknown `kty` and no `alg` are dropped instead of inheriting the (attacker-influenced) JWT header algorithm.

### Reliability

- **Per-user token refresh lock** — auto-refresh runs on `init` with no serialization, so parallel requests (multiple tabs/asset requests) could replay a rotated refresh token; rotation-enforcing IdPs treat that as token reuse and may revoke the whole token family, logging the user out. A 30s transient lock now serializes refreshes; it is released on success and left to expire on failure to throttle retry storms.
- **Refresh response validation** — `refresh_token()` now enforces the same RFC 6749 §5.1 checks as the login-time exchange (`access_token` present, `token_type` present and Bearer).
- **Refresh timeout 30s → 10s** — the refresh blocks page loads, so a slow IdP can no longer hang requests for half a minute.

### Features

- **"Remember Users" setting** + `secure_oidc_login_remember_user` filter — the persistent 14-day auth cookie was previously hardcoded; it's now configurable (default unchanged), with a session-cookie option that aligns the WP session more closely with the IdP session.
- **`client_id` on RP-initiated logout** per OIDC RP-Initiated Logout 1.0, letting the IdP validate `post_logout_redirect_uri` even when it can't use `id_token_hint`.

## Testing

- 16 new unit tests covering discovery validation, refresh response validation, Basic-auth encoding, JWKS key filtering, and lock behavior
- Full suite: **448 tests / 1030 assertions pass**; PHPStan and PHPCS clean
- Recommended manual check: one login/logout round-trip against a real IdP (none available in the dev environment)

## Backward compatibility

All defaults preserve current behavior. The only intentional behavior changes are fail-closed validations: discovery documents with mismatched issuers or non-HTTPS endpoints are rejected, and callbacks carrying a wrong `iss` are rejected.

## Future work (documented, not implemented)

- Back-channel logout (WP sessions currently survive IdP logout)
- `max_age` request parameter + `auth_time` validation to complement ACR enforcement
- `login_hint`/`prompt` passthrough

https://claude.ai/code/session_01QHWgMJR5kqZKKNDdkZ3Ugp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHWgMJR5kqZKKNDdkZ3Ugp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Remember Users" setting to choose between 14-day persistent login or session-based logout

* **Security**
  * Enhanced OIDC provider discovery validation with issuer verification and HTTPS enforcement
  * Added login CSRF protection via state parameter binding
  * Strengthened refresh token validation
  * Improved concurrent refresh token handling to prevent token reuse

<!-- end of auto-generated comment: release notes by coderabbit.ai -->