### PR TITLE
Add back-channel logout, max_age/auth_time validation, and login hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Back-channel logout support (OIDC Back-Channel Logout 1.0): the IdP can terminate WordPress sessions server-to-server via `/secure-oidc-login/v1/backchannel-logout`, with full logout token validation and single-use `jti` replay protection
+- `max_age` request parameter with `auth_time` claim verification (OIDC Core 3.1.3.7 step 13) via the new "Max Authentication Age" setting
+- `prompt` setting (`login`/`consent`/`select_account`) and `login_hint` passthrough on the login initiation URL
+- `secure_oidc_login_auth_params` filter for IdP-specific authorization request parameters (security-critical parameters cannot be overridden)
+- "Remember Users" login setting and `secure_oidc_login_remember_user` filter to control the persistent 14-day auth cookie (previously always enabled)
+- `client_id` parameter on RP-initiated logout requests per OIDC RP-Initiated Logout 1.0
+
 ### Security
 - Bind the OIDC `state` to the initiating browser via an `HttpOnly` cookie, preventing login-CSRF / forced-login (session fixation)
 - Validate the discovery document `issuer` against the discovery URL (OIDC Discovery 1.0 §4.3) and require HTTPS on all advertised endpoints
 - Validate the RFC 9207 `iss` authorization response parameter on the callback; required when the IdP advertises support during discovery (IdP mix-up defense)
 - Form-urlencode `client_id`/`client_secret` in HTTP Basic credentials per RFC 6749 §2.3.1
 - Drop JWKS keys with an unknown `kty` instead of assigning them the JWT header algorithm
-
-### Added
-- "Remember Users" login setting and `secure_oidc_login_remember_user` filter to control the persistent 14-day auth cookie (previously always enabled)
-- `client_id` parameter on RP-initiated logout requests per OIDC RP-Initiated Logout 1.0
 
 ### Fixed
 - Serialize automatic token refresh with a per-user lock so parallel requests cannot replay a rotated refresh token (which rotation-enforcing IdPs treat as reuse and may revoke the session)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The endpoint validates the signed logout token per OIDC Back-Channel Logout 1.0 
 
 A login link can pre-fill the IdP's identifier field by adding `login_hint` to the initiation URL:
 
-```
+```text
 https://example.com/wp-login.php?oidc_login=1&login_hint=user@example.com
 ```
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Navigate to **Settings > OIDC Auth** in your WordPress admin panel.
 | End Session Endpoint | URL for logout/end session | No |
 | Issuer | Expected issuer value for token validation | Yes |
 | Scope | OAuth scopes to request (default: `openid email profile`) | No |
+| Max Authentication Age | Maximum seconds since the user last authenticated at the IdP (`max_age` request parameter). When set, the ID token `auth_time` claim is required and verified. 0 disables. | No |
+| Prompt | OIDC `prompt` parameter: provider default, `login` (always re-prompt for credentials), `consent`, or `select_account` | No |
 
 #### Login Settings
 
@@ -134,7 +136,24 @@ Navigate to **Settings > OIDC Auth** in your WordPress admin panel.
 |---------|-------------|
 | Login Button Text | Text displayed on the SSO login button |
 | Enable Single Logout | When enabled, logging out of WordPress also logs out of the IdP |
+| Enable Back-Channel Logout | End WordPress sessions when the IdP reports a logout (OIDC Back-Channel Logout 1.0). Register `<site>/?rest_route=/secure-oidc-login/v1/backchannel-logout` (shown on the settings page) as the back-channel logout URI at your IdP. |
 | Remember Users | Keep users logged in with WordPress's persistent 14-day cookie (default). Disable to use a session cookie that expires when the browser closes, aligning the WordPress session more closely with the IdP session. Also filterable via `secure_oidc_login_remember_user`. |
+
+### Back-Channel Logout
+
+When enabled, the IdP can terminate WordPress sessions directly (server-to-server) the moment the user's IdP session ends — logout at the IdP, an admin-forced logout, or a session timeout. Without it, WordPress sessions survive until the auth cookie expires.
+
+The endpoint validates the signed logout token per OIDC Back-Channel Logout 1.0 §2.6 (signature against the JWKS, `iss`, `aud`, `events`, `sub`/`sid`, no `nonce`) with single-use `jti` replay protection, then destroys all WordPress sessions for the matched user and clears their stored tokens.
+
+### Login Hints
+
+A login link can pre-fill the IdP's identifier field by adding `login_hint` to the initiation URL:
+
+```
+https://example.com/wp-login.php?oidc_login=1&login_hint=user@example.com
+```
+
+Developers can add IdP-specific authorization request parameters with the `secure_oidc_login_auth_params` filter; security-critical parameters (state, nonce, PKCE, redirect URI) cannot be overridden.
 
 #### User Settings
 

--- a/includes/class-oidc-admin.php
+++ b/includes/class-oidc-admin.php
@@ -403,6 +403,39 @@ class OIDC_Admin {
 			)
 		);
 
+		add_settings_field(
+			'max_age',
+			__( 'Max Authentication Age (seconds)', 'secure-oidc-login' ),
+			array( $this, 'render_number_field' ),
+			'secure-oidc-login',
+			'oidc_provider_section',
+			array(
+				'field'       => 'max_age',
+				'default'     => 0,
+				'min'         => 0,
+				'max'         => 31536000,
+				'description' => __( 'Maximum elapsed time since the user last authenticated at the IdP. If exceeded, the IdP must re-authenticate them, and the ID token auth_time claim is verified. 0 disables.', 'secure-oidc-login' ),
+			)
+		);
+
+		add_settings_field(
+			'prompt',
+			__( 'Prompt', 'secure-oidc-login' ),
+			array( $this, 'render_radio_field' ),
+			'secure-oidc-login',
+			'oidc_provider_section',
+			array(
+				'field'   => 'prompt',
+				'options' => array(
+					''               => __( 'Provider default (no prompt parameter)', 'secure-oidc-login' ),
+					'login'          => __( 'login — always re-prompt for credentials', 'secure-oidc-login' ),
+					'consent'        => __( 'consent — always re-prompt for consent', 'secure-oidc-login' ),
+					'select_account' => __( 'select_account — always show the account chooser', 'secure-oidc-login' ),
+				),
+				'default' => '',
+			)
+		);
+
 		// === Login Settings Section ===
 		add_settings_section(
 			'oidc_login_section',
@@ -432,6 +465,22 @@ class OIDC_Admin {
 			array(
 				'field'       => 'enable_single_logout',
 				'description' => __( 'Logout from identity provider when logging out of WordPress.', 'secure-oidc-login' ),
+			)
+		);
+
+		add_settings_field(
+			'enable_backchannel_logout',
+			__( 'Enable Back-Channel Logout', 'secure-oidc-login' ),
+			array( $this, 'render_checkbox_field' ),
+			'secure-oidc-login',
+			'oidc_login_section',
+			array(
+				'field'       => 'enable_backchannel_logout',
+				'description' => sprintf(
+					/* translators: %s: back-channel logout endpoint URL */
+					__( 'End WordPress sessions when the identity provider reports a logout (OIDC Back-Channel Logout 1.0). Register this URL as the back-channel logout URI at your IdP: %s', 'secure-oidc-login' ),
+					rest_url( 'secure-oidc-login/v1/backchannel-logout' )
+				),
 			)
 		);
 
@@ -676,7 +725,7 @@ class OIDC_Admin {
 		);
 
 		// Boolean checkbox fields
-		$checkbox_fields = array( 'enable_single_logout', 'create_users', 'require_verified_email', 'disable_native_login', 'enable_auto_token_refresh', 'enforce_refresh_token_rotation', 'enforce_acr', 'remember_user' );
+		$checkbox_fields = array( 'enable_single_logout', 'create_users', 'require_verified_email', 'disable_native_login', 'enable_auto_token_refresh', 'enforce_refresh_token_rotation', 'enforce_acr', 'remember_user', 'enable_backchannel_logout' );
 
 		// Integer number fields with validation
 		$number_fields = array(
@@ -684,6 +733,11 @@ class OIDC_Admin {
 				'min'     => 60,
 				'max'     => 3600,
 				'default' => 300,
+			),
+			'max_age'              => array(
+				'min'     => 0,
+				'max'     => 31536000,
+				'default' => 0,
 			),
 		);
 
@@ -786,6 +840,10 @@ class OIDC_Admin {
 			'token_endpoint_auth_method' => array(
 				'allowed' => array( 'client_secret_basic', 'client_secret_post' ),
 				'default' => 'client_secret_basic',
+			),
+			'prompt'                     => array(
+				'allowed' => array( '', 'none', 'login', 'consent', 'select_account' ),
+				'default' => '',
 			),
 		);
 

--- a/includes/class-oidc-admin.php
+++ b/includes/class-oidc-admin.php
@@ -842,7 +842,10 @@ class OIDC_Admin {
 				'default' => 'client_secret_basic',
 			),
 			'prompt'                     => array(
-				'allowed' => array( '', 'none', 'login', 'consent', 'select_account' ),
+				// 'none' is intentionally excluded: it fails interactive logins with
+				// login_required whenever the IdP has no session. Developers who need
+				// it can use the secure_oidc_login_auth_params filter.
+				'allowed' => array( '', 'login', 'consent', 'select_account' ),
 				'default' => '',
 			),
 		);

--- a/includes/class-oidc-backchannel-logout.php
+++ b/includes/class-oidc-backchannel-logout.php
@@ -1,0 +1,179 @@
+<?php
+declare(strict_types=1);
+/**
+ * Back-channel logout handling per OIDC Back-Channel Logout 1.0.
+ *
+ * @package Secure_OIDC_Login
+ * @since 1.4.0
+ */
+
+// Prevent direct file access
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Terminates WordPress sessions in response to IdP-initiated logout.
+ *
+ * The IdP POSTs a signed logout token directly to this site's back-channel
+ * endpoint when the user's IdP session ends (logout at the IdP, admin-forced
+ * logout, session timeout). Without this, WordPress sessions survive until the
+ * auth cookie expires - up to 14 days after the IdP session ended.
+ */
+class OIDC_Backchannel_Logout {
+
+	/**
+	 * User meta key holding the SHA-256 hash of the IdP session ID (sid claim).
+	 *
+	 * Hashed so raw IdP session identifiers are never stored in the database;
+	 * lookups compare hashes, which is all the logout flow needs.
+	 *
+	 * @var string
+	 */
+	const SID_HASH_META_KEY = 'oidc_sid_hash';
+
+	/**
+	 * OIDC Client for logout token validation.
+	 *
+	 * @var OIDC_Client
+	 */
+	private OIDC_Client $client;
+
+	/**
+	 * Token Manager for clearing stored tokens.
+	 *
+	 * @var OIDC_Token_Manager
+	 */
+	private OIDC_Token_Manager $token_manager;
+
+	/**
+	 * Initialize the back-channel logout handler.
+	 *
+	 * @param OIDC_Client        $client        The OIDC client for token validation.
+	 * @param OIDC_Token_Manager $token_manager The token manager for cleanup.
+	 */
+	public function __construct( OIDC_Client $client, OIDC_Token_Manager $token_manager ) {
+		$this->client        = $client;
+		$this->token_manager = $token_manager;
+	}
+
+	/**
+	 * Record the IdP session ID for a user at login time.
+	 *
+	 * Called from the OIDC callback when the ID token carries a sid claim, so a
+	 * later logout token containing only sid can be mapped back to the user.
+	 *
+	 * @param int                  $user_id The WordPress user ID.
+	 * @param array<string, mixed> $claims  Validated ID token claims.
+	 * @return void
+	 */
+	public static function store_session_id( int $user_id, array $claims ): void {
+		if ( ! empty( $claims['sid'] ) && is_string( $claims['sid'] ) ) {
+			update_user_meta( $user_id, self::SID_HASH_META_KEY, hash( 'sha256', $claims['sid'] ) );
+		}
+	}
+
+	/**
+	 * Process a back-channel logout request.
+	 *
+	 * Validates the logout token, resolves the affected user, and destroys all
+	 * of their WordPress sessions. Per OIDC Back-Channel Logout 1.0 Section 2.8
+	 * the response is 200 on success and 400 for an invalid request.
+	 *
+	 * @param string $logout_token The raw logout token from the request body.
+	 * @return true|WP_Error True if processed, WP_Error (invalid token) otherwise.
+	 */
+	public function handle_logout_token( string $logout_token ): bool|WP_Error {
+		$claims = $this->client->validate_logout_token( $logout_token );
+		if ( is_wp_error( $claims ) ) {
+			error_log( '[Secure OIDC Login] Back-channel logout token rejected: ' . $claims->get_error_message() );
+			return $claims;
+		}
+
+		$sub_user = ! empty( $claims['sub'] ) ? $this->get_user_by_subject( (string) $claims['sub'] ) : null;
+		$sid_user = ! empty( $claims['sid'] ) ? $this->get_user_by_sid( (string) $claims['sid'] ) : null;
+
+		// SECURITY: If both identifiers are present they must agree; a token whose
+		// sub and sid point at different accounts is malformed or mixed up.
+		if ( $sub_user && $sid_user && $sub_user->ID !== $sid_user->ID ) {
+			error_log( '[Secure OIDC Login] Back-channel logout rejected: sub and sid resolve to different users.' );
+			return new WP_Error( 'oidc_error', __( 'Logout token sub and sid identify different users.', 'secure-oidc-login' ) );
+		}
+
+		$user = $sub_user ?? $sid_user;
+
+		// No matching user/session: return success without acting. The token was
+		// validly signed by the IdP, so this is a session we never had (or already
+		// cleaned up) - and a uniform success response avoids confirming which
+		// subjects have accounts here (Section 2.8 allows 200 when there is
+		// nothing to log out).
+		if ( null === $user ) {
+			return true;
+		}
+
+		$this->terminate_user_sessions( $user->ID );
+
+		error_log(
+			sprintf(
+				'[Secure OIDC Login] Back-channel logout: terminated sessions for user %d',
+				$user->ID
+			)
+		);
+
+		return true;
+	}
+
+	/**
+	 * Destroy all WordPress sessions and stored OIDC state for a user.
+	 *
+	 * The logout token's sid identifies one IdP session, but only the most
+	 * recent sid per user is tracked, so all WordPress sessions for the user
+	 * are destroyed - the conservative reading the spec permits.
+	 *
+	 * @param int $user_id The WordPress user ID.
+	 * @return void
+	 */
+	private function terminate_user_sessions( int $user_id ): void {
+		$sessions = WP_Session_Tokens::get_instance( $user_id );
+		$sessions->destroy_all();
+
+		$this->token_manager->clear_tokens( $user_id );
+		delete_user_meta( $user_id, self::SID_HASH_META_KEY );
+	}
+
+	/**
+	 * Find a WordPress user by their OIDC subject identifier.
+	 *
+	 * @param string $subject The sub claim value.
+	 * @return WP_User|null User object or null if not found.
+	 */
+	private function get_user_by_subject( string $subject ): ?WP_User {
+		$users = get_users(
+			array(
+				'meta_key'   => 'oidc_subject',
+				'meta_value' => $subject,
+				'number'     => 1,
+			)
+		);
+
+		return ! empty( $users ) ? $users[0] : null;
+	}
+
+	/**
+	 * Find a WordPress user by the hash of their IdP session ID.
+	 *
+	 * @param string $sid The sid claim value.
+	 * @return WP_User|null User object or null if not found.
+	 */
+	private function get_user_by_sid( string $sid ): ?WP_User {
+		$users = get_users(
+			array(
+				'meta_key'   => self::SID_HASH_META_KEY,
+				'meta_value' => hash( 'sha256', $sid ),
+				'number'     => 1,
+			)
+		);
+
+		return ! empty( $users ) ? $users[0] : null;
+	}
+}

--- a/includes/class-oidc-backchannel-logout.php
+++ b/includes/class-oidc-backchannel-logout.php
@@ -23,14 +23,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 class OIDC_Backchannel_Logout {
 
 	/**
-	 * User meta key holding the SHA-256 hash of the IdP session ID (sid claim).
+	 * User meta key holding SHA-256 hashes of the IdP session IDs (sid claims).
 	 *
-	 * Hashed so raw IdP session identifiers are never stored in the database;
-	 * lookups compare hashes, which is all the logout flow needs.
+	 * One meta row per IdP session (non-unique meta), so logout tokens for any
+	 * of a user's concurrent IdP sessions can be correlated. Hashed so raw IdP
+	 * session identifiers are never stored in the database; lookups compare
+	 * hashes, which is all the logout flow needs.
 	 *
 	 * @var string
 	 */
 	const SID_HASH_META_KEY = 'oidc_sid_hash';
+
+	/**
+	 * Maximum number of IdP session hashes tracked per user.
+	 *
+	 * Bounds user-meta growth for IdPs that issue a fresh sid on every login.
+	 * When exceeded, older associations are dropped; their sessions can still
+	 * be logged out via the logout token's sub claim.
+	 *
+	 * @var int
+	 */
+	const MAX_TRACKED_SIDS = 10;
 
 	/**
 	 * OIDC Client for logout token validation.
@@ -62,15 +75,34 @@ class OIDC_Backchannel_Logout {
 	 *
 	 * Called from the OIDC callback when the ID token carries a sid claim, so a
 	 * later logout token containing only sid can be mapped back to the user.
+	 * Each sid is stored as its own meta row (appended, not overwritten) so
+	 * concurrent IdP sessions - e.g. two browsers - all remain correlated.
 	 *
 	 * @param int                  $user_id The WordPress user ID.
 	 * @param array<string, mixed> $claims  Validated ID token claims.
 	 * @return void
 	 */
 	public static function store_session_id( int $user_id, array $claims ): void {
-		if ( ! empty( $claims['sid'] ) && is_string( $claims['sid'] ) ) {
-			update_user_meta( $user_id, self::SID_HASH_META_KEY, hash( 'sha256', $claims['sid'] ) );
+		if ( empty( $claims['sid'] ) || ! is_string( $claims['sid'] ) ) {
+			return;
 		}
+
+		$sid_hash = hash( 'sha256', $claims['sid'] );
+		$existing = get_user_meta( $user_id, self::SID_HASH_META_KEY, false );
+		$existing = is_array( $existing ) ? $existing : array();
+
+		// Same IdP session re-authenticating: already tracked.
+		if ( in_array( $sid_hash, $existing, true ) ) {
+			return;
+		}
+
+		// Bound growth: past the cap, drop all older associations rather than
+		// growing forever. Affected sessions remain reachable via the sub claim.
+		if ( count( $existing ) >= self::MAX_TRACKED_SIDS ) {
+			delete_user_meta( $user_id, self::SID_HASH_META_KEY );
+		}
+
+		add_user_meta( $user_id, self::SID_HASH_META_KEY, $sid_hash );
 	}
 
 	/**
@@ -126,9 +158,10 @@ class OIDC_Backchannel_Logout {
 	/**
 	 * Destroy all WordPress sessions and stored OIDC state for a user.
 	 *
-	 * The logout token's sid identifies one IdP session, but only the most
-	 * recent sid per user is tracked, so all WordPress sessions for the user
-	 * are destroyed - the conservative reading the spec permits.
+	 * The logout token's sid identifies one IdP session, but WordPress sessions
+	 * are not mapped one-to-one to IdP sessions, so all WordPress sessions for
+	 * the user are destroyed - the conservative reading the spec permits.
+	 * delete_user_meta() without a value removes every tracked sid row.
 	 *
 	 * @param int $user_id The WordPress user ID.
 	 * @return void

--- a/includes/class-oidc-client.php
+++ b/includes/class-oidc-client.php
@@ -606,8 +606,9 @@ class OIDC_Client {
 		}
 
 		// REPLAY PROTECTION: each jti may only be used once (step 8). The cache
-		// window only needs to cover the token's validity, which exp already
-		// bounds; 10 minutes comfortably exceeds typical logout token lifetimes.
+		// must outlive the token's JWT validity, so the TTL is derived from exp
+		// (plus clock-skew leeway), with a floor of 10 minutes and a cap of one
+		// day to keep a misconfigured IdP from creating long-lived transients.
 		if ( empty( $claims['jti'] ) || ! is_string( $claims['jti'] ) ) {
 			return new WP_Error( 'oidc_error', __( 'Logout token is missing the required jti claim.', 'secure-oidc-login' ) );
 		}
@@ -616,7 +617,9 @@ class OIDC_Client {
 		if ( false !== get_transient( $jti_key ) ) {
 			return new WP_Error( 'oidc_error', __( 'Logout token has already been used.', 'secure-oidc-login' ) );
 		}
-		set_transient( $jti_key, 1, 600 );
+
+		$jti_ttl = min( max( (int) $claims['exp'] - time() + self::get_jwt_leeway(), 600 ), DAY_IN_SECONDS );
+		set_transient( $jti_key, 1, $jti_ttl );
 
 		return $claims;
 	}

--- a/includes/class-oidc-client.php
+++ b/includes/class-oidc-client.php
@@ -486,6 +486,142 @@ class OIDC_Client {
 	}
 
 	/**
+	 * Get the JWT clock-skew leeway in seconds.
+	 *
+	 * Accommodates time differences between the IdP and this server.
+	 * Default: 15 seconds. Override with the SECURE_OIDC_JWT_LEEWAY environment
+	 * variable (1-600 seconds).
+	 *
+	 * @return int Leeway in seconds.
+	 */
+	private static function get_jwt_leeway(): int {
+		$leeway     = 15; // Default: 15 seconds
+		$env_leeway = getenv( 'SECURE_OIDC_JWT_LEEWAY' );
+		if ( false !== $env_leeway && '' !== $env_leeway ) {
+			$parsed_leeway = filter_var( $env_leeway, FILTER_VALIDATE_INT );
+			if ( false !== $parsed_leeway && $parsed_leeway > 0 && $parsed_leeway <= 600 ) {
+				$leeway = $parsed_leeway;
+			} else {
+				error_log( '[Secure OIDC Login] Invalid SECURE_OIDC_JWT_LEEWAY value: ' . $env_leeway . '. Using default 15 seconds.' );
+			}
+		}
+		return $leeway;
+	}
+
+	/**
+	 * Validate the auth_time claim against the configured max_age.
+	 *
+	 * Per OIDC Core 3.1.2.1, when the max_age request parameter is used the ID
+	 * token MUST include an auth_time claim, and per 3.1.3.7 step 13 the RP
+	 * SHOULD verify that the elapsed time since authentication is within the
+	 * requested maximum. This ensures the IdP actually re-authenticated the user
+	 * rather than silently reusing an old session.
+	 *
+	 * @param array<string, mixed> $claims  The decoded ID token claims.
+	 * @param array<string, mixed> $options Plugin settings from WordPress options.
+	 * @return true|WP_Error True if validation passes, WP_Error on failure.
+	 */
+	public function validate_auth_time( array $claims, array $options ): bool|WP_Error {
+		$max_age = (int) Secure_OIDC_Login::get_setting( 'max_age', $options );
+
+		// max_age not configured: nothing was requested, nothing to enforce.
+		if ( $max_age <= 0 ) {
+			return true;
+		}
+
+		if ( ! isset( $claims['auth_time'] ) || ! is_numeric( $claims['auth_time'] ) ) {
+			return new WP_Error(
+				'oidc_auth_time_missing',
+				__( 'ID token is missing the auth_time claim required when max_age is requested.', 'secure-oidc-login' )
+			);
+		}
+
+		$elapsed = time() - (int) $claims['auth_time'];
+
+		if ( $elapsed > $max_age + self::get_jwt_leeway() ) {
+			return new WP_Error(
+				'oidc_auth_time_exceeded',
+				__( 'Authentication is older than the requested maximum age. Please sign in again.', 'secure-oidc-login' )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate a back-channel logout token per OIDC Back-Channel Logout 1.0 Section 2.6.
+	 *
+	 * The logout token is a JWT delivered by the IdP directly to this site (not
+	 * through the browser), so it is the sole authentication for the logout
+	 * request. Validation: signature via JWKS (same asymmetric allowlist as ID
+	 * tokens), iss, aud, exp/iat (enforced by the JWT library), the required
+	 * events claim, presence of sub and/or sid, absence of nonce, and single-use
+	 * jti (replay cache).
+	 *
+	 * @param string $logout_token The JWT logout token from the IdP.
+	 * @return array<string, mixed>|WP_Error Verified claims array or error.
+	 */
+	public function validate_logout_token( string $logout_token ): array|WP_Error {
+		// Signature, exp, nbf, and iat are verified here (Section 2.6 step 4).
+		$claims = $this->decode_and_verify_jwt( $logout_token );
+		if ( is_wp_error( $claims ) ) {
+			return $claims;
+		}
+		unset( $claims['__jwt_alg'] );
+
+		// Verify iss matches the configured issuer (step 4).
+		$issuer = $this->get_setting( 'issuer' );
+		if ( empty( $issuer ) || ! isset( $claims['iss'] ) || $claims['iss'] !== $issuer ) {
+			return new WP_Error( 'oidc_error', __( 'Invalid logout token issuer.', 'secure-oidc-login' ) );
+		}
+
+		// Verify aud contains this client_id (step 4).
+		$client_id = $this->get_setting( 'client_id' );
+		$aud       = isset( $claims['aud'] ) ? ( is_array( $claims['aud'] ) ? $claims['aud'] : array( $claims['aud'] ) ) : array();
+		if ( empty( $client_id ) || ! in_array( $client_id, $aud, true ) ) {
+			return new WP_Error( 'oidc_error', __( 'Invalid logout token audience.', 'secure-oidc-login' ) );
+		}
+
+		// iat and exp are REQUIRED claims in logout tokens (Section 2.4); the JWT
+		// library only enforces them when present, so require them explicitly.
+		if ( ! isset( $claims['iat'] ) || ! isset( $claims['exp'] ) ) {
+			return new WP_Error( 'oidc_error', __( 'Logout token is missing required iat or exp claim.', 'secure-oidc-login' ) );
+		}
+
+		// Verify the events claim identifies this as a logout token (step 6).
+		$logout_event = 'http://schemas.openid.net/event/backchannel-logout';
+		if ( ! isset( $claims['events'] ) || ! is_array( $claims['events'] )
+			|| ! array_key_exists( $logout_event, $claims['events'] ) ) {
+			return new WP_Error( 'oidc_error', __( 'Logout token is missing the backchannel-logout event.', 'secure-oidc-login' ) );
+		}
+
+		// A nonce MUST NOT be present (step 7) - rejects ID tokens replayed as logout tokens.
+		if ( isset( $claims['nonce'] ) ) {
+			return new WP_Error( 'oidc_error', __( 'Logout token must not contain a nonce claim.', 'secure-oidc-login' ) );
+		}
+
+		// A sub and/or sid claim is required to identify what to log out (step 5).
+		if ( empty( $claims['sub'] ) && empty( $claims['sid'] ) ) {
+			return new WP_Error( 'oidc_error', __( 'Logout token must contain a sub or sid claim.', 'secure-oidc-login' ) );
+		}
+
+		// REPLAY PROTECTION: each jti may only be used once (step 8). The cache
+		// window only needs to cover the token's validity, which exp already
+		// bounds; 10 minutes comfortably exceeds typical logout token lifetimes.
+		if ( empty( $claims['jti'] ) || ! is_string( $claims['jti'] ) ) {
+			return new WP_Error( 'oidc_error', __( 'Logout token is missing the required jti claim.', 'secure-oidc-login' ) );
+		}
+
+		$jti_key = 'oidc_bcl_jti_' . hash( 'sha256', $claims['jti'] );
+		if ( false !== get_transient( $jti_key ) ) {
+			return new WP_Error( 'oidc_error', __( 'Logout token has already been used.', 'secure-oidc-login' ) );
+		}
+		set_transient( $jti_key, 1, 600 );
+
+		return $claims;
+	}
+
+	/**
 	 * Decode and verify a JWT using Firebase JWT library.
 	 *
 	 * Performs signature verification, expiration validation, and decoding.
@@ -566,17 +702,7 @@ class OIDC_Client {
 			// This accommodates time differences between IdP and WordPress server
 			// Default: 15 seconds (reduced from 5 minutes for better security)
 			// Override with SECURE_OIDC_JWT_LEEWAY environment variable (in seconds)
-			$leeway     = 15; // Default: 15 seconds
-			$env_leeway = getenv( 'SECURE_OIDC_JWT_LEEWAY' );
-			if ( false !== $env_leeway && '' !== $env_leeway ) {
-				$parsed_leeway = filter_var( $env_leeway, FILTER_VALIDATE_INT );
-				if ( false !== $parsed_leeway && $parsed_leeway > 0 && $parsed_leeway <= 600 ) {
-					$leeway = $parsed_leeway;
-				} else {
-					error_log( '[Secure OIDC Login] Invalid SECURE_OIDC_JWT_LEEWAY value: ' . $env_leeway . '. Using default 15 seconds.' );
-				}
-			}
-			JWT::$leeway = $leeway;
+			JWT::$leeway = self::get_jwt_leeway();
 
 			// Decode and verify JWT (automatically validates signature, exp, nbf, iat)
 			$decoded = JWT::decode( $jwt, $keys );

--- a/includes/class-oidc-rest-controller.php
+++ b/includes/class-oidc-rest-controller.php
@@ -39,10 +39,20 @@ class OIDC_REST_Controller extends WP_REST_Controller {
 	private $rate_limiter;
 
 	/**
-	 * Constructor - Initialize rate limiter.
+	 * Back-channel logout handler, created lazily for the logout route.
+	 *
+	 * @var OIDC_Backchannel_Logout|null
 	 */
-	public function __construct() {
-		$this->rate_limiter = new OIDC_Rate_Limiter();
+	private ?OIDC_Backchannel_Logout $backchannel_handler;
+
+	/**
+	 * Constructor - Initialize rate limiter.
+	 *
+	 * @param OIDC_Backchannel_Logout|null $backchannel_handler Optional handler override for testing.
+	 */
+	public function __construct( ?OIDC_Backchannel_Logout $backchannel_handler = null ) {
+		$this->rate_limiter        = new OIDC_Rate_Limiter();
+		$this->backchannel_handler = $backchannel_handler;
 	}
 
 	/**
@@ -67,6 +77,91 @@ class OIDC_REST_Controller extends WP_REST_Controller {
 				),
 			)
 		);
+
+		register_rest_route(
+			$this->namespace,
+			'/backchannel-logout',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'backchannel_logout' ),
+				// SECURITY: This endpoint is called server-to-server by the IdP, not by a
+				// logged-in browser, so there is no WordPress authentication context. The
+				// request is authenticated by the signed logout token itself (signature,
+				// iss, aud, events, jti) in OIDC_Client::validate_logout_token().
+				'permission_callback' => '__return_true',
+				'args'                => array(
+					'logout_token' => array(
+						'required'    => true,
+						'type'        => 'string',
+						'description' => __( 'The signed OIDC logout token (JWT).', 'secure-oidc-login' ),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Handle a back-channel logout request from the IdP.
+	 *
+	 * Per OIDC Back-Channel Logout 1.0 Section 2.8: 200 on success, 400 for an
+	 * invalid request, both with Cache-Control: no-store.
+	 *
+	 * @param WP_REST_Request<array<string, mixed>> $request The REST request.
+	 * @return WP_REST_Response The logout response.
+	 */
+	public function backchannel_logout( WP_REST_Request $request ): WP_REST_Response {
+		// SECURITY: Rate limit to blunt brute-force attempts against token validation
+		if ( $this->rate_limiter->is_rate_limited( 'backchannel_logout' ) ) {
+			return $this->backchannel_response( array( 'error' => 'invalid_request' ), 429 );
+		}
+		$this->rate_limiter->record_attempt( 'backchannel_logout' );
+
+		$options = get_option( 'secure_oidc_login_settings', array() );
+		if ( empty( $options['enable_backchannel_logout'] ) ) {
+			// Feature disabled: respond 400 rather than 404 to avoid signaling
+			// whether the plugin is installed vs. merely unconfigured.
+			return $this->backchannel_response( array( 'error' => 'invalid_request' ), 400 );
+		}
+
+		$logout_token = $request->get_param( 'logout_token' );
+		if ( ! is_string( $logout_token ) || '' === $logout_token ) {
+			return $this->backchannel_response( array( 'error' => 'invalid_request' ), 400 );
+		}
+
+		$result = $this->get_backchannel_handler()->handle_logout_token( $logout_token );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->backchannel_response( array( 'error' => 'invalid_request' ), 400 );
+		}
+
+		// Successful logout (or validly-signed token with nothing to log out).
+		return $this->backchannel_response( null, 200 );
+	}
+
+	/**
+	 * Build a back-channel logout response with the spec-required cache headers.
+	 *
+	 * @param array<string, string>|null $body   Response body, or null for an empty body.
+	 * @param int                        $status HTTP status code.
+	 * @return WP_REST_Response The response object.
+	 */
+	private function backchannel_response( ?array $body, int $status ): WP_REST_Response {
+		$response = new WP_REST_Response( $body, $status );
+		// Section 2.8: the RP's response MUST include Cache-Control: no-store.
+		$response->header( 'Cache-Control', 'no-store' );
+		return $response;
+	}
+
+	/**
+	 * Get the back-channel logout handler, creating it on first use.
+	 *
+	 * @return OIDC_Backchannel_Logout The handler instance.
+	 */
+	private function get_backchannel_handler(): OIDC_Backchannel_Logout {
+		if ( null === $this->backchannel_handler ) {
+			$this->backchannel_handler = new OIDC_Backchannel_Logout( new OIDC_Client(), new OIDC_Token_Manager() );
+		}
+		return $this->backchannel_handler;
 	}
 
 	/**

--- a/includes/class-oidc-rest-controller.php
+++ b/includes/class-oidc-rest-controller.php
@@ -118,8 +118,18 @@ class OIDC_REST_Controller extends WP_REST_Controller {
 		}
 		$this->rate_limiter->record_attempt( 'backchannel_logout' );
 
+		// The SECURE_OIDC_ENABLE_BACKCHANNEL_LOGOUT environment variable overrides the
+		// stored setting, matching how the admin UI presents env-managed checkboxes
+		// (same true/false convention as SECURE_OIDC_ENFORCE_ACR).
 		$options = get_option( 'secure_oidc_login_settings', array() );
-		if ( empty( $options['enable_backchannel_logout'] ) ) {
+		$enabled = ! empty( $options['enable_backchannel_logout'] );
+
+		$env_enabled = getenv( 'SECURE_OIDC_ENABLE_BACKCHANNEL_LOGOUT' );
+		if ( false !== $env_enabled && '' !== $env_enabled ) {
+			$enabled = 'true' === strtolower( (string) $env_enabled );
+		}
+
+		if ( ! $enabled ) {
 			// Feature disabled: respond 400 rather than 404 to avoid signaling
 			// whether the plugin is installed vs. merely unconfigured.
 			return $this->backchannel_response( array( 'error' => 'invalid_request' ), 400 );

--- a/includes/class-oidc-rest-controller.php
+++ b/includes/class-oidc-rest-controller.php
@@ -110,9 +110,11 @@ class OIDC_REST_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response The logout response.
 	 */
 	public function backchannel_logout( WP_REST_Request $request ): WP_REST_Response {
-		// SECURITY: Rate limit to blunt brute-force attempts against token validation
+		// SECURITY: Rate limit to blunt brute-force attempts against token validation.
+		// 400 (not 429) keeps the response within the status codes defined by OIDC
+		// Back-Channel Logout 1.0 Section 2.8, which strictly conforming IdPs expect.
 		if ( $this->rate_limiter->is_rate_limited( 'backchannel_logout' ) ) {
-			return $this->backchannel_response( array( 'error' => 'invalid_request' ), 429 );
+			return $this->backchannel_response( array( 'error' => 'invalid_request' ), 400 );
 		}
 		$this->rate_limiter->record_attempt( 'backchannel_logout' );
 

--- a/secure-oidc-login.php
+++ b/secure-oidc-login.php
@@ -62,6 +62,7 @@ require_once SECURE_OIDC_LOGIN_PLUGIN_DIR . 'includes/class-oidc-rest-controller
 require_once SECURE_OIDC_LOGIN_PLUGIN_DIR . 'includes/class-oidc-rate-limiter.php';
 require_once SECURE_OIDC_LOGIN_PLUGIN_DIR . 'includes/class-oidc-token-manager.php';
 require_once SECURE_OIDC_LOGIN_PLUGIN_DIR . 'includes/class-oidc-token-refresh.php';
+require_once SECURE_OIDC_LOGIN_PLUGIN_DIR . 'includes/class-oidc-backchannel-logout.php';
 
 /**
  * Main plugin class implementing OpenID Connect authentication for WordPress.
@@ -515,6 +516,60 @@ class Secure_OIDC_Login {
 			$auth_params['acr_values'] = $acr_values;
 		}
 
+		// max_age: maximum elapsed time since the user last authenticated at the
+		// IdP (OIDC Core 3.1.2.1). The matching auth_time claim is enforced on the
+		// callback via OIDC_Client::validate_auth_time().
+		$max_age = (int) self::get_setting( 'max_age', $options );
+		if ( $max_age > 0 ) {
+			$auth_params['max_age'] = (string) $max_age;
+		}
+
+		// prompt: instructs the IdP whether to re-prompt the user (OIDC Core 3.1.2.1).
+		$prompt = self::get_setting( 'prompt', $options );
+		if ( ! empty( $prompt ) ) {
+			$auth_params['prompt'] = $prompt;
+		}
+
+		// login_hint passthrough: lets a login link pre-fill the IdP's identifier
+		// field, e.g. wp-login.php?oidc_login=1&login_hint=user@example.com.
+		// A hint only affects the IdP's login UX; identity still comes from the
+		// validated ID token.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Optional UX hint on the login-initiation URL; initiate_login() issues a fresh state/PKCE challenge.
+		if ( ! empty( $_GET['login_hint'] ) && is_string( $_GET['login_hint'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- See above.
+			$login_hint = sanitize_text_field( wp_unslash( $_GET['login_hint'] ) );
+			if ( '' !== $login_hint && strlen( $login_hint ) <= 255 ) {
+				$auth_params['login_hint'] = $login_hint;
+			}
+		}
+
+		/**
+		 * Filter the authorization request parameters.
+		 *
+		 * Allows adding IdP-specific parameters (e.g. audience, resource, ui_locales).
+		 * Security-critical parameters (response_type, client_id, redirect_uri, state,
+		 * nonce, PKCE) are re-applied after the filter and cannot be overridden.
+		 *
+		 * @param array<string, string> $auth_params The authorization request parameters.
+		 */
+		$filtered_params = apply_filters( 'secure_oidc_login_auth_params', $auth_params );
+		if ( is_array( $filtered_params ) ) {
+			// SECURITY: Re-assert the parameters the protocol's security depends on so
+			// a filter cannot weaken CSRF/replay/code-interception protections.
+			$auth_params = array_merge(
+				$filtered_params,
+				array(
+					'response_type'         => 'code',
+					'client_id'             => $client_id,
+					'redirect_uri'          => $redirect_uri,
+					'state'                 => $state,
+					'nonce'                 => $nonce,
+					'code_challenge'        => $code_challenge,
+					'code_challenge_method' => 'S256',
+				)
+			);
+		}
+
 		$auth_url = $authorization_endpoint . '?' . http_build_query( $auth_params );
 
 		wp_redirect( $auth_url ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- Redirect to the external IdP authorization endpoint; wp_safe_redirect() would reject the off-site host.
@@ -671,6 +726,14 @@ class Secure_OIDC_Login {
 			return;
 		}
 
+		// Validate auth_time against max_age if configured (OIDC Core 3.1.3.7 step 13)
+		$auth_time_result = $this->client->validate_auth_time( $id_token_claims, $options );
+
+		if ( is_wp_error( $auth_time_result ) ) {
+			$this->handle_error( $auth_time_result->get_error_message() );
+			return;
+		}
+
 		// Fetch additional user info from userinfo endpoint
 		$userinfo = $this->client->get_userinfo( $tokens['access_token'] );
 
@@ -718,6 +781,10 @@ class Secure_OIDC_Login {
 			);
 			return;
 		}
+
+		// Record the IdP session ID (sid claim) so a back-channel logout token
+		// carrying only sid can be mapped back to this user.
+		OIDC_Backchannel_Logout::store_session_id( $user->ID, $id_token_claims );
 
 		// Clear rate limits on successful authentication
 		$this->rate_limiter->clear_limit( 'callback' );
@@ -1020,6 +1087,9 @@ class Secure_OIDC_Login {
 			'scope'                                 => 'openid email profile',
 			'acr_values'                            => '',
 			'enforce_acr'                           => false,
+			'max_age'                               => 0,
+			'prompt'                                => '',
+			'enable_backchannel_logout'             => false,
 			'login_button_text'                     => 'Login with SSO',
 			'enable_single_logout'                  => false,
 			'disable_native_login'                  => false,

--- a/tests/Unit/Client/OIDCClientTest.php
+++ b/tests/Unit/Client/OIDCClientTest.php
@@ -2892,4 +2892,248 @@ class OIDCClientTest extends OIDCTestCase
         // With the only key dropped, the key set is empty and verification must fail
         $this->assertInstanceOf(WP_Error::class, $result);
     }
+
+    // =========================================================================
+    // auth_time / max_age Validation Tests (OIDC Core 3.1.3.7 step 13)
+    // =========================================================================
+
+    /**
+     * Test validate_auth_time passes when max_age is not configured.
+     */
+    public function testValidateAuthTimePassesWhenMaxAgeNotConfigured(): void
+    {
+        putenv('SECURE_OIDC_MAX_AGE');
+
+        $result = $this->client->validate_auth_time(
+            ['sub' => 'user-123'],
+            ['max_age' => 0]
+        );
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test validate_auth_time passes for a recent authentication.
+     */
+    public function testValidateAuthTimePassesForRecentAuth(): void
+    {
+        putenv('SECURE_OIDC_MAX_AGE');
+
+        $result = $this->client->validate_auth_time(
+            ['sub' => 'user-123', 'auth_time' => time() - 10],
+            ['max_age' => 300]
+        );
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * Test validate_auth_time rejects a missing auth_time when max_age is set.
+     */
+    public function testValidateAuthTimeRejectsMissingAuthTime(): void
+    {
+        putenv('SECURE_OIDC_MAX_AGE');
+
+        $result = $this->client->validate_auth_time(
+            ['sub' => 'user-123'],
+            ['max_age' => 300]
+        );
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('oidc_auth_time_missing', $result->get_error_code());
+    }
+
+    /**
+     * Test validate_auth_time rejects authentication older than max_age.
+     */
+    public function testValidateAuthTimeRejectsStaleAuth(): void
+    {
+        putenv('SECURE_OIDC_MAX_AGE');
+
+        $result = $this->client->validate_auth_time(
+            ['sub' => 'user-123', 'auth_time' => time() - 1000],
+            ['max_age' => 300]
+        );
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('oidc_auth_time_exceeded', $result->get_error_code());
+    }
+
+    // =========================================================================
+    // Logout Token Validation Tests (OIDC Back-Channel Logout 1.0 Section 2.6)
+    // =========================================================================
+
+    /**
+     * Build a complete, valid set of logout token claims.
+     *
+     * @param array<string, mixed> $overrides Claims to add or replace.
+     * @return array<string, mixed> Logout token claims.
+     */
+    private function getSampleLogoutTokenClaims(array $overrides = []): array
+    {
+        $claims = [
+            'iss' => 'https://idp.example.com',
+            'aud' => 'test-client-id',
+            'iat' => time(),
+            'exp' => time() + 120,
+            'jti' => 'logout-jti-123',
+            'events' => ['http://schemas.openid.net/event/backchannel-logout' => []],
+            'sub' => 'user-123-abc',
+        ];
+
+        return array_merge($claims, $overrides);
+    }
+
+    /**
+     * Test validate_logout_token accepts a fully valid logout token.
+     */
+    public function testValidateLogoutTokenAcceptsValidToken(): void
+    {
+        $set_jti_keys = [];
+        Functions\when('set_transient')->alias(function ($key, $value, $ttl) use (&$set_jti_keys) {
+            $set_jti_keys[] = $key;
+            return true;
+        });
+
+        $client = $this->createClientWithStubbedJwt($this->getSampleLogoutTokenClaims());
+
+        $result = $client->validate_logout_token('header.payload.signature');
+
+        $this->assertIsArray($result);
+        $this->assertSame('user-123-abc', $result['sub']);
+        // The jti must be recorded for replay protection
+        $this->assertNotEmpty(array_filter($set_jti_keys, fn($k) => str_starts_with($k, 'oidc_bcl_jti_')));
+    }
+
+    /**
+     * Test validate_logout_token rejects a replayed jti.
+     */
+    public function testValidateLogoutTokenRejectsReplayedJti(): void
+    {
+        // The jti replay-cache transient already exists
+        Functions\when('get_transient')->alias(
+            static fn($key) => str_starts_with((string) $key, 'oidc_bcl_jti_') ? 1 : false
+        );
+
+        $client = $this->createClientWithStubbedJwt($this->getSampleLogoutTokenClaims());
+
+        $result = $client->validate_logout_token('header.payload.signature');
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertStringContainsString('already been used', $result->get_error_message());
+    }
+
+    /**
+     * Test validate_logout_token rejects a token containing a nonce.
+     *
+     * Per Section 2.6 step 7 this blocks ID tokens being replayed as logout tokens.
+     */
+    public function testValidateLogoutTokenRejectsNonce(): void
+    {
+        $client = $this->createClientWithStubbedJwt(
+            $this->getSampleLogoutTokenClaims(['nonce' => 'some-nonce'])
+        );
+
+        $result = $client->validate_logout_token('header.payload.signature');
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertStringContainsString('nonce', $result->get_error_message());
+    }
+
+    /**
+     * Test validate_logout_token rejects a token without the logout event.
+     */
+    public function testValidateLogoutTokenRejectsMissingEvent(): void
+    {
+        $claims = $this->getSampleLogoutTokenClaims();
+        unset($claims['events']);
+
+        $client = $this->createClientWithStubbedJwt($claims);
+
+        $result = $client->validate_logout_token('header.payload.signature');
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertStringContainsString('event', $result->get_error_message());
+    }
+
+    /**
+     * Test validate_logout_token rejects a token with neither sub nor sid.
+     */
+    public function testValidateLogoutTokenRejectsMissingSubAndSid(): void
+    {
+        $claims = $this->getSampleLogoutTokenClaims();
+        unset($claims['sub']);
+
+        $client = $this->createClientWithStubbedJwt($claims);
+
+        $result = $client->validate_logout_token('header.payload.signature');
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertStringContainsString('sub or sid', $result->get_error_message());
+    }
+
+    /**
+     * Test validate_logout_token accepts a token identifying the session by sid only.
+     */
+    public function testValidateLogoutTokenAcceptsSidOnly(): void
+    {
+        $claims = $this->getSampleLogoutTokenClaims(['sid' => 'idp-session-1']);
+        unset($claims['sub']);
+
+        $client = $this->createClientWithStubbedJwt($claims);
+
+        $result = $client->validate_logout_token('header.payload.signature');
+
+        $this->assertIsArray($result);
+        $this->assertSame('idp-session-1', $result['sid']);
+    }
+
+    /**
+     * Test validate_logout_token rejects a wrong issuer.
+     */
+    public function testValidateLogoutTokenRejectsWrongIssuer(): void
+    {
+        $client = $this->createClientWithStubbedJwt(
+            $this->getSampleLogoutTokenClaims(['iss' => 'https://evil.example.org'])
+        );
+
+        $result = $client->validate_logout_token('header.payload.signature');
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertStringContainsString('issuer', $result->get_error_message());
+    }
+
+    /**
+     * Test validate_logout_token rejects a wrong audience.
+     */
+    public function testValidateLogoutTokenRejectsWrongAudience(): void
+    {
+        $client = $this->createClientWithStubbedJwt(
+            $this->getSampleLogoutTokenClaims(['aud' => 'other-client'])
+        );
+
+        $result = $client->validate_logout_token('header.payload.signature');
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertStringContainsString('audience', $result->get_error_message());
+    }
+
+    /**
+     * Test validate_logout_token rejects missing iat/exp and missing jti.
+     */
+    public function testValidateLogoutTokenRejectsMissingRequiredClaims(): void
+    {
+        // Missing exp
+        $claims = $this->getSampleLogoutTokenClaims();
+        unset($claims['exp']);
+        $result = $this->createClientWithStubbedJwt($claims)->validate_logout_token('h.p.s');
+        $this->assertInstanceOf(WP_Error::class, $result);
+
+        // Missing jti
+        $claims = $this->getSampleLogoutTokenClaims();
+        unset($claims['jti']);
+        $result = $this->createClientWithStubbedJwt($claims)->validate_logout_token('h.p.s');
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertStringContainsString('jti', $result->get_error_message());
+    }
 }

--- a/tests/Unit/Client/OIDCClientTest.php
+++ b/tests/Unit/Client/OIDCClientTest.php
@@ -3030,6 +3030,14 @@ class OIDCClientTest extends OIDCTestCase
 
         $this->assertIsArray($result);
         $this->assertGreaterThanOrEqual(3600, $captured_ttl);
+
+        // A short-lived token still gets the 10-minute minimum replay-cache TTL
+        $client = $this->createClientWithStubbedJwt(
+            $this->getSampleLogoutTokenClaims(['exp' => time() + 30, 'jti' => 'jti-short'])
+        );
+        $client->validate_logout_token('header.payload.signature');
+        $this->assertGreaterThanOrEqual(600, $captured_ttl);
+
         // And it is capped at one day even for absurd exp values
         $client = $this->createClientWithStubbedJwt(
             $this->getSampleLogoutTokenClaims(['exp' => time() + 10 * 86400, 'jti' => 'jti-far-future'])

--- a/tests/Unit/Client/OIDCClientTest.php
+++ b/tests/Unit/Client/OIDCClientTest.php
@@ -3006,6 +3006,39 @@ class OIDCClientTest extends OIDCTestCase
     }
 
     /**
+     * Test the jti replay cache lifetime covers the token's full validity window.
+     *
+     * A fixed cache TTL shorter than the token's exp would let the same logout
+     * token be replayed once the cache entry expires while the JWT is still valid.
+     */
+    public function testValidateLogoutTokenJtiCacheCoversTokenLifetime(): void
+    {
+        $captured_ttl = null;
+        Functions\when('set_transient')->alias(function ($key, $value, $ttl) use (&$captured_ttl) {
+            if (str_starts_with((string) $key, 'oidc_bcl_jti_')) {
+                $captured_ttl = $ttl;
+            }
+            return true;
+        });
+
+        // Token valid for one hour - the replay cache must last at least that long
+        $client = $this->createClientWithStubbedJwt(
+            $this->getSampleLogoutTokenClaims(['exp' => time() + 3600])
+        );
+
+        $result = $client->validate_logout_token('header.payload.signature');
+
+        $this->assertIsArray($result);
+        $this->assertGreaterThanOrEqual(3600, $captured_ttl);
+        // And it is capped at one day even for absurd exp values
+        $client = $this->createClientWithStubbedJwt(
+            $this->getSampleLogoutTokenClaims(['exp' => time() + 10 * 86400, 'jti' => 'jti-far-future'])
+        );
+        $client->validate_logout_token('header.payload.signature');
+        $this->assertLessThanOrEqual(86400, $captured_ttl);
+    }
+
+    /**
      * Test validate_logout_token rejects a replayed jti.
      */
     public function testValidateLogoutTokenRejectsReplayedJti(): void

--- a/tests/Unit/Logout/OIDCBackchannelLogoutTest.php
+++ b/tests/Unit/Logout/OIDCBackchannelLogoutTest.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * Tests for OIDC_Backchannel_Logout class.
+ *
+ * @package SecureOIDCLogin\Tests\Unit\Logout
+ */
+
+declare(strict_types=1);
+
+namespace SecureOIDCLogin\Tests\Unit\Logout;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use OIDC_Backchannel_Logout;
+use OIDC_Client;
+use OIDC_Token_Manager;
+use SecureOIDCLogin\Tests\OIDCTestCase;
+use WP_Error;
+use WP_Session_Tokens;
+use WP_User;
+
+/**
+ * Tests for the OIDC_Backchannel_Logout class.
+ *
+ * @covers OIDC_Backchannel_Logout
+ */
+class OIDCBackchannelLogoutTest extends OIDCTestCase
+{
+    /**
+     * Mock OIDC_Client.
+     *
+     * @var OIDC_Client|Mockery\MockInterface
+     */
+    private $client;
+
+    /**
+     * Mock OIDC_Token_Manager.
+     *
+     * @var OIDC_Token_Manager|Mockery\MockInterface
+     */
+    private $token_manager;
+
+    /**
+     * Handler under test.
+     *
+     * @var OIDC_Backchannel_Logout
+     */
+    private OIDC_Backchannel_Logout $handler;
+
+    /**
+     * Set up test environment.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        WP_Session_Tokens::reset();
+
+        $this->client = Mockery::mock(OIDC_Client::class);
+        $this->token_manager = Mockery::mock(OIDC_Token_Manager::class);
+
+        $this->handler = new OIDC_Backchannel_Logout($this->client, $this->token_manager);
+    }
+
+    /**
+     * Build a WP_User with the given ID.
+     *
+     * @param int $id The user ID.
+     * @return WP_User The user object.
+     */
+    private function makeUser(int $id): WP_User
+    {
+        $user = new WP_User();
+        $user->ID = $id;
+        return $user;
+    }
+
+    /**
+     * Valid logout token claims identifying a user by sub.
+     *
+     * @param array<string, mixed> $overrides Claims to add or replace.
+     * @return array<string, mixed> Logout token claims.
+     */
+    private function logoutClaims(array $overrides = []): array
+    {
+        return array_merge(
+            [
+                'iss' => 'https://idp.example.com',
+                'aud' => 'test-client-id',
+                'jti' => 'jti-1',
+                'events' => ['http://schemas.openid.net/event/backchannel-logout' => []],
+                'sub' => 'user-123-abc',
+            ],
+            $overrides
+        );
+    }
+
+    /**
+     * Test store_session_id stores the SHA-256 hash of the sid claim.
+     */
+    public function testStoreSessionIdStoresHashedSid(): void
+    {
+        $stored = [];
+        Functions\when('update_user_meta')->alias(function ($user_id, $key, $value) use (&$stored) {
+            $stored[$key] = $value;
+            return true;
+        });
+
+        OIDC_Backchannel_Logout::store_session_id(42, ['sid' => 'idp-session-1']);
+
+        $this->assertSame(hash('sha256', 'idp-session-1'), $stored['oidc_sid_hash']);
+    }
+
+    /**
+     * Test store_session_id does nothing without a sid claim.
+     */
+    public function testStoreSessionIdSkipsWithoutSid(): void
+    {
+        $called = false;
+        Functions\when('update_user_meta')->alias(function () use (&$called) {
+            $called = true;
+            return true;
+        });
+
+        OIDC_Backchannel_Logout::store_session_id(42, ['sub' => 'user-123-abc']);
+
+        $this->assertFalse($called);
+    }
+
+    /**
+     * Test handle_logout_token propagates token validation errors.
+     */
+    public function testHandleLogoutTokenPropagatesValidationError(): void
+    {
+        $error = new WP_Error('oidc_error', 'Invalid logout token issuer.');
+
+        $this->client
+            ->shouldReceive('validate_logout_token')
+            ->with('bad.token.here')
+            ->once()
+            ->andReturn($error);
+
+        $result = $this->handler->handle_logout_token('bad.token.here');
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame([], WP_Session_Tokens::$destroyed_user_ids);
+    }
+
+    /**
+     * Test handle_logout_token terminates sessions for a user matched by sub.
+     */
+    public function testHandleLogoutTokenTerminatesSessionsBySub(): void
+    {
+        $user = $this->makeUser(42);
+
+        $this->client
+            ->shouldReceive('validate_logout_token')
+            ->once()
+            ->andReturn($this->logoutClaims());
+
+        // Lookup by oidc_subject meta finds the user
+        Functions\when('get_users')->alias(function ($args) use ($user) {
+            return 'oidc_subject' === $args['meta_key'] ? [$user] : [];
+        });
+
+        $deleted_meta = [];
+        Functions\when('delete_user_meta')->alias(function ($user_id, $key) use (&$deleted_meta) {
+            $deleted_meta[] = [$user_id, $key];
+            return true;
+        });
+
+        $this->token_manager
+            ->shouldReceive('clear_tokens')
+            ->with(42)
+            ->once();
+
+        $result = $this->handler->handle_logout_token('valid.token.here');
+
+        $this->assertTrue($result);
+        $this->assertSame([42], WP_Session_Tokens::$destroyed_user_ids);
+        $this->assertContains([42, 'oidc_sid_hash'], $deleted_meta);
+    }
+
+    /**
+     * Test handle_logout_token terminates sessions for a user matched by sid only.
+     */
+    public function testHandleLogoutTokenTerminatesSessionsBySid(): void
+    {
+        $user = $this->makeUser(7);
+        $claims = $this->logoutClaims(['sid' => 'idp-session-1']);
+        unset($claims['sub']);
+
+        $this->client
+            ->shouldReceive('validate_logout_token')
+            ->once()
+            ->andReturn($claims);
+
+        Functions\when('get_users')->alias(function ($args) use ($user) {
+            if ('oidc_sid_hash' === $args['meta_key']
+                && hash('sha256', 'idp-session-1') === $args['meta_value']) {
+                return [$user];
+            }
+            return [];
+        });
+
+        Functions\when('delete_user_meta')->justReturn(true);
+
+        $this->token_manager
+            ->shouldReceive('clear_tokens')
+            ->with(7)
+            ->once();
+
+        $result = $this->handler->handle_logout_token('valid.token.here');
+
+        $this->assertTrue($result);
+        $this->assertSame([7], WP_Session_Tokens::$destroyed_user_ids);
+    }
+
+    /**
+     * Test handle_logout_token rejects a token whose sub and sid identify different users.
+     */
+    public function testHandleLogoutTokenRejectsSubSidUserMismatch(): void
+    {
+        $sub_user = $this->makeUser(42);
+        $sid_user = $this->makeUser(99);
+
+        $this->client
+            ->shouldReceive('validate_logout_token')
+            ->once()
+            ->andReturn($this->logoutClaims(['sid' => 'idp-session-1']));
+
+        Functions\when('get_users')->alias(function ($args) use ($sub_user, $sid_user) {
+            return 'oidc_subject' === $args['meta_key'] ? [$sub_user] : [$sid_user];
+        });
+
+        $this->token_manager->shouldNotReceive('clear_tokens');
+
+        $result = $this->handler->handle_logout_token('valid.token.here');
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame([], WP_Session_Tokens::$destroyed_user_ids);
+    }
+
+    /**
+     * Test handle_logout_token succeeds quietly when no user matches.
+     *
+     * A validly-signed token for an unknown subject returns 200 to avoid
+     * confirming which subjects have accounts on this site.
+     */
+    public function testHandleLogoutTokenSucceedsWhenNoUserMatches(): void
+    {
+        $this->client
+            ->shouldReceive('validate_logout_token')
+            ->once()
+            ->andReturn($this->logoutClaims());
+
+        Functions\when('get_users')->justReturn([]);
+
+        $this->token_manager->shouldNotReceive('clear_tokens');
+
+        $result = $this->handler->handle_logout_token('valid.token.here');
+
+        $this->assertTrue($result);
+        $this->assertSame([], WP_Session_Tokens::$destroyed_user_ids);
+    }
+}

--- a/tests/Unit/Logout/OIDCBackchannelLogoutTest.php
+++ b/tests/Unit/Logout/OIDCBackchannelLogoutTest.php
@@ -96,19 +96,91 @@ class OIDCBackchannelLogoutTest extends OIDCTestCase
     }
 
     /**
-     * Test store_session_id stores the SHA-256 hash of the sid claim.
+     * Test store_session_id stores the SHA-256 hash of the sid claim as a new meta row.
      */
     public function testStoreSessionIdStoresHashedSid(): void
     {
-        $stored = [];
-        Functions\when('update_user_meta')->alias(function ($user_id, $key, $value) use (&$stored) {
-            $stored[$key] = $value;
-            return true;
+        $added = [];
+        Functions\when('get_user_meta')->justReturn([]);
+        Functions\when('add_user_meta')->alias(function ($user_id, $key, $value) use (&$added) {
+            $added[$key] = $value;
+            return 1;
         });
 
         OIDC_Backchannel_Logout::store_session_id(42, ['sid' => 'idp-session-1']);
 
-        $this->assertSame(hash('sha256', 'idp-session-1'), $stored['oidc_sid_hash']);
+        $this->assertSame(hash('sha256', 'idp-session-1'), $added['oidc_sid_hash']);
+    }
+
+    /**
+     * Test store_session_id appends a second concurrent session instead of overwriting.
+     */
+    public function testStoreSessionIdAppendsConcurrentSessions(): void
+    {
+        $added = [];
+        $deleted = false;
+
+        // A different IdP session is already tracked
+        Functions\when('get_user_meta')->justReturn([hash('sha256', 'idp-session-1')]);
+        Functions\when('add_user_meta')->alias(function ($user_id, $key, $value) use (&$added) {
+            $added[] = $value;
+            return 2;
+        });
+        Functions\when('delete_user_meta')->alias(function () use (&$deleted) {
+            $deleted = true;
+            return true;
+        });
+
+        OIDC_Backchannel_Logout::store_session_id(42, ['sid' => 'idp-session-2']);
+
+        $this->assertSame([hash('sha256', 'idp-session-2')], $added);
+        $this->assertFalse($deleted, 'Existing session hashes must not be removed below the cap');
+    }
+
+    /**
+     * Test store_session_id does not duplicate an already-tracked session.
+     */
+    public function testStoreSessionIdSkipsDuplicateSid(): void
+    {
+        $added = false;
+        Functions\when('get_user_meta')->justReturn([hash('sha256', 'idp-session-1')]);
+        Functions\when('add_user_meta')->alias(function () use (&$added) {
+            $added = true;
+            return 1;
+        });
+
+        OIDC_Backchannel_Logout::store_session_id(42, ['sid' => 'idp-session-1']);
+
+        $this->assertFalse($added);
+    }
+
+    /**
+     * Test store_session_id resets tracked hashes once the cap is reached.
+     */
+    public function testStoreSessionIdResetsAtCap(): void
+    {
+        $existing = [];
+        for ($i = 0; $i < OIDC_Backchannel_Logout::MAX_TRACKED_SIDS; $i++) {
+            $existing[] = hash('sha256', "idp-session-{$i}");
+        }
+
+        $deleted = false;
+        $added = [];
+
+        Functions\when('get_user_meta')->justReturn($existing);
+        Functions\when('delete_user_meta')->alias(function () use (&$deleted) {
+            $deleted = true;
+            return true;
+        });
+        Functions\when('add_user_meta')->alias(function ($user_id, $key, $value) use (&$added) {
+            $added[] = $value;
+            return 1;
+        });
+
+        OIDC_Backchannel_Logout::store_session_id(42, ['sid' => 'idp-session-new']);
+
+        $this->assertTrue($deleted);
+        $this->assertSame([hash('sha256', 'idp-session-new')], $added);
     }
 
     /**
@@ -117,9 +189,10 @@ class OIDCBackchannelLogoutTest extends OIDCTestCase
     public function testStoreSessionIdSkipsWithoutSid(): void
     {
         $called = false;
-        Functions\when('update_user_meta')->alias(function () use (&$called) {
+        Functions\when('get_user_meta')->justReturn([]);
+        Functions\when('add_user_meta')->alias(function () use (&$called) {
             $called = true;
-            return true;
+            return 1;
         });
 
         OIDC_Backchannel_Logout::store_session_id(42, ['sub' => 'user-123-abc']);
@@ -128,11 +201,17 @@ class OIDCBackchannelLogoutTest extends OIDCTestCase
     }
 
     /**
-     * Test handle_logout_token propagates token validation errors.
+     * Test handle_logout_token propagates token validation errors with no side effects.
      */
     public function testHandleLogoutTokenPropagatesValidationError(): void
     {
         $error = new WP_Error('oidc_error', 'Invalid logout token issuer.');
+        $meta_deleted = false;
+
+        Functions\when('delete_user_meta')->alias(function () use (&$meta_deleted) {
+            $meta_deleted = true;
+            return true;
+        });
 
         $this->client
             ->shouldReceive('validate_logout_token')
@@ -140,10 +219,13 @@ class OIDCBackchannelLogoutTest extends OIDCTestCase
             ->once()
             ->andReturn($error);
 
+        $this->token_manager->shouldNotReceive('clear_tokens');
+
         $result = $this->handler->handle_logout_token('bad.token.here');
 
         $this->assertInstanceOf(WP_Error::class, $result);
         $this->assertSame([], WP_Session_Tokens::$destroyed_user_ids);
+        $this->assertFalse($meta_deleted);
     }
 
     /**
@@ -223,6 +305,12 @@ class OIDCBackchannelLogoutTest extends OIDCTestCase
     {
         $sub_user = $this->makeUser(42);
         $sid_user = $this->makeUser(99);
+        $meta_deleted = false;
+
+        Functions\when('delete_user_meta')->alias(function () use (&$meta_deleted) {
+            $meta_deleted = true;
+            return true;
+        });
 
         $this->client
             ->shouldReceive('validate_logout_token')
@@ -239,6 +327,7 @@ class OIDCBackchannelLogoutTest extends OIDCTestCase
 
         $this->assertInstanceOf(WP_Error::class, $result);
         $this->assertSame([], WP_Session_Tokens::$destroyed_user_ids);
+        $this->assertFalse($meta_deleted);
     }
 
     /**

--- a/tests/Unit/REST/OIDCRestControllerTest.php
+++ b/tests/Unit/REST/OIDCRestControllerTest.php
@@ -660,7 +660,8 @@ class OIDCRestControllerTest extends OIDCTestCase
         $routes = $this->captureRegisteredRoutes();
 
         // WP_REST_Server::CREATABLE is 'POST'
-        $this->assertArrayHasKey('methods', $routes['/discover']['args']);
+        $this->assertSame(\WP_REST_Server::CREATABLE, $routes['/discover']['args']['methods']);
+        $this->assertSame(\WP_REST_Server::CREATABLE, $routes['/backchannel-logout']['args']['methods']);
     }
 
     /**
@@ -1061,8 +1062,12 @@ class OIDCRestControllerTest extends OIDCTestCase
 
         $controller = new OIDC_REST_Controller($handler);
 
+        // Only answer for the exact parameter name the controller must use
         $request = $this->createMock(WP_REST_Request::class);
-        $request->method('get_param')->willReturn($logout_token);
+        $request->method('get_param')
+            ->willReturnCallback(
+                static fn (string $key) => 'logout_token' === $key ? $logout_token : null
+            );
 
         return [$controller, $request];
     }

--- a/tests/Unit/REST/OIDCRestControllerTest.php
+++ b/tests/Unit/REST/OIDCRestControllerTest.php
@@ -1130,9 +1130,12 @@ class OIDCRestControllerTest extends OIDCTestCase
     }
 
     /**
-     * Test backchannel_logout returns 429 when rate limited.
+     * Test backchannel_logout returns 400 when rate limited.
+     *
+     * 400 rather than 429 keeps the response within the status codes defined by
+     * OIDC Back-Channel Logout 1.0 Section 2.8.
      */
-    public function testBackchannelLogoutReturns429WhenRateLimited(): void
+    public function testBackchannelLogoutReturns400WhenRateLimited(): void
     {
         Functions\when('get_option')->justReturn(['enable_backchannel_logout' => true]);
 
@@ -1145,6 +1148,6 @@ class OIDCRestControllerTest extends OIDCTestCase
 
         $result = $controller->backchannel_logout($request);
 
-        $this->assertSame(429, $result->get_status());
+        $this->assertSame(400, $result->get_status());
     }
 }

--- a/tests/Unit/REST/OIDCRestControllerTest.php
+++ b/tests/Unit/REST/OIDCRestControllerTest.php
@@ -1121,6 +1121,47 @@ class OIDCRestControllerTest extends OIDCTestCase
     }
 
     /**
+     * Test the SECURE_OIDC_ENABLE_BACKCHANNEL_LOGOUT env var overrides the stored setting.
+     */
+    public function testBackchannelLogoutHonorsEnvOverride(): void
+    {
+        putenv('SECURE_OIDC_ENABLE_BACKCHANNEL_LOGOUT=true');
+
+        try {
+            // Stored setting disabled, but the env var enables the endpoint
+            Functions\when('get_option')->justReturn(['enable_backchannel_logout' => false]);
+
+            [$controller, $request] = $this->buildBackchannelScenario(true, 'valid.logout.token');
+
+            $result = $controller->backchannel_logout($request);
+
+            $this->assertSame(200, $result->get_status());
+        } finally {
+            putenv('SECURE_OIDC_ENABLE_BACKCHANNEL_LOGOUT');
+        }
+    }
+
+    /**
+     * Test the env var can also disable the endpoint despite the stored setting.
+     */
+    public function testBackchannelLogoutEnvOverrideCanDisable(): void
+    {
+        putenv('SECURE_OIDC_ENABLE_BACKCHANNEL_LOGOUT=false');
+
+        try {
+            Functions\when('get_option')->justReturn(['enable_backchannel_logout' => true]);
+
+            [$controller, $request] = $this->buildBackchannelScenario(null, 'any.logout.token');
+
+            $result = $controller->backchannel_logout($request);
+
+            $this->assertSame(400, $result->get_status());
+        } finally {
+            putenv('SECURE_OIDC_ENABLE_BACKCHANNEL_LOGOUT');
+        }
+    }
+
+    /**
      * Test backchannel_logout returns 400 for an empty token.
      */
     public function testBackchannelLogoutReturns400OnEmptyToken(): void

--- a/tests/Unit/REST/OIDCRestControllerTest.php
+++ b/tests/Unit/REST/OIDCRestControllerTest.php
@@ -617,16 +617,17 @@ class OIDCRestControllerTest extends OIDCTestCase
     }
 
     /**
-     * Test register_routes registers the discover endpoint.
+     * Capture all routes registered by register_routes(), keyed by route path.
+     *
+     * @return array<string, array<string, mixed>> Route args keyed by route path.
      */
-    public function testRegisterRoutesRegistersDiscoverEndpoint(): void
+    private function captureRegisteredRoutes(): array
     {
         $registeredRoutes = [];
 
         Functions\when('register_rest_route')->alias(function ($namespace, $route, $args) use (&$registeredRoutes) {
-            $registeredRoutes[] = [
+            $registeredRoutes[$route] = [
                 'namespace' => $namespace,
-                'route' => $route,
                 'args' => $args,
             ];
             return true;
@@ -634,9 +635,21 @@ class OIDCRestControllerTest extends OIDCTestCase
 
         $this->controller->register_routes();
 
-        $this->assertCount(1, $registeredRoutes);
-        $this->assertSame('secure-oidc-login/v1', $registeredRoutes[0]['namespace']);
-        $this->assertSame('/discover', $registeredRoutes[0]['route']);
+        return $registeredRoutes;
+    }
+
+    /**
+     * Test register_routes registers the discover and backchannel-logout endpoints.
+     */
+    public function testRegisterRoutesRegistersDiscoverEndpoint(): void
+    {
+        $routes = $this->captureRegisteredRoutes();
+
+        $this->assertCount(2, $routes);
+        $this->assertArrayHasKey('/discover', $routes);
+        $this->assertArrayHasKey('/backchannel-logout', $routes);
+        $this->assertSame('secure-oidc-login/v1', $routes['/discover']['namespace']);
+        $this->assertSame('secure-oidc-login/v1', $routes['/backchannel-logout']['namespace']);
     }
 
     /**
@@ -644,18 +657,10 @@ class OIDCRestControllerTest extends OIDCTestCase
      */
     public function testRegisterRoutesConfiguresPostMethod(): void
     {
-        $registeredArgs = null;
+        $routes = $this->captureRegisteredRoutes();
 
-        Functions\when('register_rest_route')->alias(function ($namespace, $route, $args) use (&$registeredArgs) {
-            $registeredArgs = $args;
-            return true;
-        });
-
-        $this->controller->register_routes();
-
-        $this->assertNotNull($registeredArgs);
         // WP_REST_Server::CREATABLE is 'POST'
-        $this->assertArrayHasKey('methods', $registeredArgs);
+        $this->assertArrayHasKey('methods', $routes['/discover']['args']);
     }
 
     /**
@@ -663,17 +668,10 @@ class OIDCRestControllerTest extends OIDCTestCase
      */
     public function testRegisterRoutesConfiguresPermissionCallback(): void
     {
-        $registeredArgs = null;
+        $routes = $this->captureRegisteredRoutes();
 
-        Functions\when('register_rest_route')->alias(function ($namespace, $route, $args) use (&$registeredArgs) {
-            $registeredArgs = $args;
-            return true;
-        });
-
-        $this->controller->register_routes();
-
-        $this->assertArrayHasKey('permission_callback', $registeredArgs);
-        $this->assertIsCallable($registeredArgs['permission_callback']);
+        $this->assertArrayHasKey('permission_callback', $routes['/discover']['args']);
+        $this->assertIsCallable($routes['/discover']['args']['permission_callback']);
     }
 
     /**
@@ -681,18 +679,12 @@ class OIDCRestControllerTest extends OIDCTestCase
      */
     public function testRegisterRoutesConfiguresDiscoveryUrlAsRequired(): void
     {
-        $registeredArgs = null;
+        $routes = $this->captureRegisteredRoutes();
+        $args = $routes['/discover']['args'];
 
-        Functions\when('register_rest_route')->alias(function ($namespace, $route, $args) use (&$registeredArgs) {
-            $registeredArgs = $args;
-            return true;
-        });
-
-        $this->controller->register_routes();
-
-        $this->assertArrayHasKey('args', $registeredArgs);
-        $this->assertArrayHasKey('discovery_url', $registeredArgs['args']);
-        $this->assertTrue($registeredArgs['args']['discovery_url']['required']);
+        $this->assertArrayHasKey('args', $args);
+        $this->assertArrayHasKey('discovery_url', $args['args']);
+        $this->assertTrue($args['args']['discovery_url']['required']);
     }
 
     /**
@@ -700,17 +692,11 @@ class OIDCRestControllerTest extends OIDCTestCase
      */
     public function testRegisterRoutesConfiguresValidateCallback(): void
     {
-        $registeredArgs = null;
+        $routes = $this->captureRegisteredRoutes();
+        $args = $routes['/discover']['args'];
 
-        Functions\when('register_rest_route')->alias(function ($namespace, $route, $args) use (&$registeredArgs) {
-            $registeredArgs = $args;
-            return true;
-        });
-
-        $this->controller->register_routes();
-
-        $this->assertArrayHasKey('validate_callback', $registeredArgs['args']['discovery_url']);
-        $this->assertIsCallable($registeredArgs['args']['discovery_url']['validate_callback']);
+        $this->assertArrayHasKey('validate_callback', $args['args']['discovery_url']);
+        $this->assertIsCallable($args['args']['discovery_url']['validate_callback']);
     }
 
     /**
@@ -718,17 +704,24 @@ class OIDCRestControllerTest extends OIDCTestCase
      */
     public function testRegisterRoutesConfiguresSanitizeCallback(): void
     {
-        $registeredArgs = null;
+        $routes = $this->captureRegisteredRoutes();
+        $args = $routes['/discover']['args'];
 
-        Functions\when('register_rest_route')->alias(function ($namespace, $route, $args) use (&$registeredArgs) {
-            $registeredArgs = $args;
-            return true;
-        });
+        $this->assertArrayHasKey('sanitize_callback', $args['args']['discovery_url']);
+        $this->assertSame('esc_url_raw', $args['args']['discovery_url']['sanitize_callback']);
+    }
 
-        $this->controller->register_routes();
+    /**
+     * Test the backchannel-logout route is public (authenticated by the logout token).
+     */
+    public function testRegisterRoutesBackchannelLogoutIsPublicAndRequiresToken(): void
+    {
+        $routes = $this->captureRegisteredRoutes();
+        $args = $routes['/backchannel-logout']['args'];
 
-        $this->assertArrayHasKey('sanitize_callback', $registeredArgs['args']['discovery_url']);
-        $this->assertSame('esc_url_raw', $registeredArgs['args']['discovery_url']['sanitize_callback']);
+        // Authenticated by the signed logout token, not a WP session
+        $this->assertSame('__return_true', $args['permission_callback']);
+        $this->assertTrue($args['args']['logout_token']['required']);
     }
 
     /**
@@ -1040,5 +1033,118 @@ class OIDCRestControllerTest extends OIDCTestCase
         // Should not have double slashes
         $this->assertStringNotContainsString('//.well-known', $requestedUrl);
         $this->assertStringContainsString('/.well-known/openid-configuration', $requestedUrl);
+    }
+
+    // =========================================================================
+    // Back-Channel Logout Endpoint Tests
+    // =========================================================================
+
+    /**
+     * Build a controller with a mocked back-channel handler and a request carrying a token.
+     *
+     * @param mixed       $handler_result Result for handle_logout_token, or null to expect no call.
+     * @param string|null $logout_token   The logout_token request parameter value.
+     * @return array{0: OIDC_REST_Controller, 1: WP_REST_Request} Controller and request.
+     */
+    private function buildBackchannelScenario(mixed $handler_result, ?string $logout_token): array
+    {
+        $handler = \Mockery::mock(\OIDC_Backchannel_Logout::class);
+
+        if (null === $handler_result) {
+            $handler->shouldNotReceive('handle_logout_token');
+        } else {
+            $handler->shouldReceive('handle_logout_token')
+                ->with($logout_token)
+                ->once()
+                ->andReturn($handler_result);
+        }
+
+        $controller = new OIDC_REST_Controller($handler);
+
+        $request = $this->createMock(WP_REST_Request::class);
+        $request->method('get_param')->willReturn($logout_token);
+
+        return [$controller, $request];
+    }
+
+    /**
+     * Test backchannel_logout returns 200 with no-store on success.
+     */
+    public function testBackchannelLogoutReturns200OnSuccess(): void
+    {
+        Functions\when('get_option')->justReturn(['enable_backchannel_logout' => true]);
+
+        [$controller, $request] = $this->buildBackchannelScenario(true, 'valid.logout.token');
+
+        $result = $controller->backchannel_logout($request);
+
+        $this->assertInstanceOf(WP_REST_Response::class, $result);
+        $this->assertSame(200, $result->get_status());
+        $this->assertSame('no-store', $result->get_headers()['Cache-Control'] ?? null);
+    }
+
+    /**
+     * Test backchannel_logout returns 400 for an invalid logout token.
+     */
+    public function testBackchannelLogoutReturns400OnInvalidToken(): void
+    {
+        Functions\when('get_option')->justReturn(['enable_backchannel_logout' => true]);
+
+        [$controller, $request] = $this->buildBackchannelScenario(
+            new WP_Error('oidc_error', 'Invalid logout token issuer.'),
+            'forged.logout.token'
+        );
+
+        $result = $controller->backchannel_logout($request);
+
+        $this->assertSame(400, $result->get_status());
+        $this->assertSame(['error' => 'invalid_request'], $result->get_data());
+    }
+
+    /**
+     * Test backchannel_logout returns 400 when the feature is disabled.
+     */
+    public function testBackchannelLogoutReturns400WhenDisabled(): void
+    {
+        Functions\when('get_option')->justReturn(['enable_backchannel_logout' => false]);
+
+        [$controller, $request] = $this->buildBackchannelScenario(null, 'any.logout.token');
+
+        $result = $controller->backchannel_logout($request);
+
+        $this->assertSame(400, $result->get_status());
+    }
+
+    /**
+     * Test backchannel_logout returns 400 for an empty token.
+     */
+    public function testBackchannelLogoutReturns400OnEmptyToken(): void
+    {
+        Functions\when('get_option')->justReturn(['enable_backchannel_logout' => true]);
+
+        [$controller, $request] = $this->buildBackchannelScenario(null, '');
+
+        $result = $controller->backchannel_logout($request);
+
+        $this->assertSame(400, $result->get_status());
+    }
+
+    /**
+     * Test backchannel_logout returns 429 when rate limited.
+     */
+    public function testBackchannelLogoutReturns429WhenRateLimited(): void
+    {
+        Functions\when('get_option')->justReturn(['enable_backchannel_logout' => true]);
+
+        // Rate limiter reads its state from transients; simulate an active lockout
+        Functions\when('get_transient')->alias(static function ($key) {
+            return str_contains((string) $key, 'lockout') ? time() + 60 : false;
+        });
+
+        [$controller, $request] = $this->buildBackchannelScenario(null, 'any.logout.token');
+
+        $result = $controller->backchannel_logout($request);
+
+        $this->assertSame(429, $result->get_status());
     }
 }

--- a/tests/Unit/REST/OIDCRestControllerTest.php
+++ b/tests/Unit/REST/OIDCRestControllerTest.php
@@ -1122,23 +1122,23 @@ class OIDCRestControllerTest extends OIDCTestCase
 
     /**
      * Test the SECURE_OIDC_ENABLE_BACKCHANNEL_LOGOUT env var overrides the stored setting.
+     *
+     * setUp() stubs getenv() to false for all vars, so the override is stubbed per-test.
      */
     public function testBackchannelLogoutHonorsEnvOverride(): void
     {
-        putenv('SECURE_OIDC_ENABLE_BACKCHANNEL_LOGOUT=true');
+        Functions\when('getenv')->alias(
+            static fn($name) => 'SECURE_OIDC_ENABLE_BACKCHANNEL_LOGOUT' === $name ? 'true' : false
+        );
 
-        try {
-            // Stored setting disabled, but the env var enables the endpoint
-            Functions\when('get_option')->justReturn(['enable_backchannel_logout' => false]);
+        // Stored setting disabled, but the env var enables the endpoint
+        Functions\when('get_option')->justReturn(['enable_backchannel_logout' => false]);
 
-            [$controller, $request] = $this->buildBackchannelScenario(true, 'valid.logout.token');
+        [$controller, $request] = $this->buildBackchannelScenario(true, 'valid.logout.token');
 
-            $result = $controller->backchannel_logout($request);
+        $result = $controller->backchannel_logout($request);
 
-            $this->assertSame(200, $result->get_status());
-        } finally {
-            putenv('SECURE_OIDC_ENABLE_BACKCHANNEL_LOGOUT');
-        }
+        $this->assertSame(200, $result->get_status());
     }
 
     /**
@@ -1146,19 +1146,17 @@ class OIDCRestControllerTest extends OIDCTestCase
      */
     public function testBackchannelLogoutEnvOverrideCanDisable(): void
     {
-        putenv('SECURE_OIDC_ENABLE_BACKCHANNEL_LOGOUT=false');
+        Functions\when('getenv')->alias(
+            static fn($name) => 'SECURE_OIDC_ENABLE_BACKCHANNEL_LOGOUT' === $name ? 'false' : false
+        );
 
-        try {
-            Functions\when('get_option')->justReturn(['enable_backchannel_logout' => true]);
+        Functions\when('get_option')->justReturn(['enable_backchannel_logout' => true]);
 
-            [$controller, $request] = $this->buildBackchannelScenario(null, 'any.logout.token');
+        [$controller, $request] = $this->buildBackchannelScenario(null, 'any.logout.token');
 
-            $result = $controller->backchannel_logout($request);
+        $result = $controller->backchannel_logout($request);
 
-            $this->assertSame(400, $result->get_status());
-        } finally {
-            putenv('SECURE_OIDC_ENABLE_BACKCHANNEL_LOGOUT');
-        }
+        $this->assertSame(400, $result->get_status());
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -64,6 +64,7 @@ require_once __DIR__ . '/stubs/class-wp-rest-controller.php';
 require_once __DIR__ . '/stubs/class-wp-rest-request.php';
 require_once __DIR__ . '/stubs/class-wp-rest-response.php';
 require_once __DIR__ . '/stubs/class-wp-rest-server.php';
+require_once __DIR__ . '/stubs/class-wp-session-tokens.php';
 require_once __DIR__ . '/stubs/class-secure-oidc-login.php';
 
 // Load plugin class files
@@ -76,3 +77,4 @@ require_once dirname(__DIR__) . '/includes/class-oidc-rest-controller.php';
 require_once dirname(__DIR__) . '/includes/class-oidc-rate-limiter.php';
 require_once dirname(__DIR__) . '/includes/class-oidc-token-manager.php';
 require_once dirname(__DIR__) . '/includes/class-oidc-token-refresh.php';
+require_once dirname(__DIR__) . '/includes/class-oidc-backchannel-logout.php';

--- a/tests/stubs/class-wp-rest-response.php
+++ b/tests/stubs/class-wp-rest-response.php
@@ -63,4 +63,32 @@ class WP_REST_Response
     {
         return $this->status;
     }
+
+    /**
+     * Response headers.
+     *
+     * @var array<string, string>
+     */
+    protected array $headers = [];
+
+    /**
+     * Set a response header.
+     *
+     * @param string $key Header name.
+     * @param string $value Header value.
+     */
+    public function header(string $key, string $value): void
+    {
+        $this->headers[$key] = $value;
+    }
+
+    /**
+     * Get response headers.
+     *
+     * @return array<string, string> Headers.
+     */
+    public function get_headers(): array
+    {
+        return $this->headers;
+    }
 }

--- a/tests/stubs/class-wp-session-tokens.php
+++ b/tests/stubs/class-wp-session-tokens.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Stub for the WordPress WP_Session_Tokens class.
+ *
+ * Records destroy_all() calls so tests can assert which users had their
+ * sessions terminated.
+ *
+ * @package SecureOIDCLogin\Tests
+ */
+
+declare(strict_types=1);
+
+if (!class_exists('WP_Session_Tokens')) {
+    /**
+     * Minimal WP_Session_Tokens stand-in for unit tests.
+     */
+    class WP_Session_Tokens
+    {
+        /**
+         * User IDs whose sessions were destroyed via destroy_all().
+         *
+         * @var array<int, int>
+         */
+        public static array $destroyed_user_ids = [];
+
+        /**
+         * The user this instance manages sessions for.
+         *
+         * @var int
+         */
+        private int $user_id;
+
+        /**
+         * @param int $user_id The WordPress user ID.
+         */
+        private function __construct(int $user_id)
+        {
+            $this->user_id = $user_id;
+        }
+
+        /**
+         * Mirror of WP_Session_Tokens::get_instance().
+         *
+         * @param int $user_id The WordPress user ID.
+         * @return self Session manager for the user.
+         */
+        public static function get_instance(int $user_id): self
+        {
+            return new self($user_id);
+        }
+
+        /**
+         * Record that all sessions for this user were destroyed.
+         */
+        public function destroy_all(): void
+        {
+            self::$destroyed_user_ids[] = $this->user_id;
+        }
+
+        /**
+         * Reset recorded state between tests.
+         */
+        public static function reset(): void
+        {
+            self::$destroyed_user_ids = [];
+        }
+    }
+}


### PR DESCRIPTION
Back-channel logout (OIDC Back-Channel Logout 1.0):
- New REST endpoint /secure-oidc-login/v1/backchannel-logout accepts
  IdP-posted logout tokens; validation per section 2.6 (signature via
  JWKS with the existing asymmetric allowlist, iss, aud, iat/exp,
  events claim, sub/sid presence, nonce rejection) plus single-use jti
  replay protection and rate limiting
- OIDC_Backchannel_Logout resolves the user by sub (oidc_subject) or
  hashed sid recorded at login, destroys all WordPress sessions, and
  clears stored tokens; unknown subjects return 200 to avoid an
  account-existence oracle
- Opt-in via the new Enable Back-Channel Logout setting; the endpoint
  URL is shown on the settings page

max_age / auth_time (OIDC Core 3.1.2.1, 3.1.3.7 step 13):
- New Max Authentication Age setting adds the max_age request
  parameter; the callback then requires and verifies the ID token
  auth_time claim against it (with the shared JWT leeway)

Login UX:
- prompt setting (login/consent/select_account)
- login_hint passthrough on the login initiation URL
- secure_oidc_login_auth_params filter; security-critical parameters
  (state, nonce, PKCE, redirect_uri) are re-asserted after filtering

30 new unit tests; PHPUnit (478 tests), PHPStan, and PHPCS all pass.

https://claude.ai/code/session_01QHWgMJR5kqZKKNDdkZ3Ugp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Back-channel logout (IdP-initiated session termination) with a new public REST endpoint
  * Authorization options: max_age (Max Authentication Age), prompt choices, login_hint passthrough, and client_id for RP-initiated logout
  * "Remember Users" 14-day persistent cookie and an extensible auth-params filter

* **Security**
  * Stronger OIDC checks: state binding to the browser, issuer/audience/iss validations, stricter JWT/nonce/jti handling, safer client credential encoding, and JWKS hardening

* **Documentation**
  * README/docs updated with new settings, back-channel logout flow, and usage notes

* **Tests**
  * Unit tests added for auth_time/max_age, logout-token validation, REST endpoint, and back-channel handler behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->