### PR TITLE
fix: support endpoints that already contain a query string

### DIFF
--- a/includes/class-oidc-url.php
+++ b/includes/class-oidc-url.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * URL helper for building OIDC endpoint URLs.
+ *
+ * @package Secure_OIDC_Login
+ */
+
+declare( strict_types = 1 );
+
+// Prevent direct file access
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Builds query URLs for OIDC endpoints that may already contain a query string.
+ *
+ * Some providers (e.g. Azure AD B2C) require a policy parameter on their
+ * authorization and end-session endpoints, so the configured endpoint can
+ * already carry a query string. Appending with a literal '?' would corrupt
+ * the resulting URL.
+ *
+ * @since 1.3.2
+ */
+class OIDC_Url {
+	/**
+	 * Append query parameters to a URL that may already contain a query string.
+	 *
+	 * Parameters are encoded with http_build_query(), which urlencodes both keys
+	 * and values (unlike add_query_arg()).
+	 *
+	 * @since 1.3.2
+	 *
+	 * @param string              $url    The endpoint URL.
+	 * @param array<string,mixed> $params Query parameters to append.
+	 * @return string The URL with parameters appended.
+	 */
+	public static function build_query_url( string $url, array $params ): string {
+		$query = http_build_query( $params );
+
+		if ( '' === $query ) {
+			return $url;
+		}
+
+		$separator = str_contains( $url, '?' ) ? '&' : '?';
+
+		return $url . $separator . $query;
+	}
+}

--- a/secure-oidc-login.php
+++ b/secure-oidc-login.php
@@ -570,7 +570,7 @@ class Secure_OIDC_Login {
 			);
 		}
 
-		$auth_url = $authorization_endpoint . '?' . http_build_query( $auth_params );
+		$auth_url = $this->build_query_url( $authorization_endpoint, $auth_params );
 
 		wp_redirect( $auth_url ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- Redirect to the external IdP authorization endpoint; wp_safe_redirect() would reject the off-site host.
 		exit;
@@ -882,7 +882,7 @@ class Secure_OIDC_Login {
 				$logout_params['client_id'] = $client_id;
 			}
 
-			$logout_url = $end_session_endpoint . '?' . http_build_query( $logout_params );
+			$logout_url = $this->build_query_url( $end_session_endpoint, $logout_params );
 
 			wp_redirect( $logout_url ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- Redirect to the external IdP end-session endpoint; wp_safe_redirect() would reject the off-site host.
 			exit;
@@ -1014,6 +1014,32 @@ class Secure_OIDC_Login {
 		}
 
 		return $parsed;
+	}
+
+	/**
+	 * Append query parameters to a URL that may already contain a query string.
+	 *
+	 * Some providers (e.g. Azure AD B2C) require a policy parameter on their
+	 * authorization and end-session endpoints, so the configured endpoint can
+	 * already carry a query string. Appending with a literal '?' would corrupt
+	 * the resulting URL.
+	 *
+	 * @since 1.3.2
+	 *
+	 * @param string              $url    The endpoint URL.
+	 * @param array<string,mixed> $params Query parameters to append.
+	 * @return string The URL with parameters appended.
+	 */
+	private function build_query_url( string $url, array $params ): string {
+		$query = http_build_query( $params );
+
+		if ( '' === $query ) {
+			return $url;
+		}
+
+		$separator = str_contains( $url, '?' ) ? '&' : '?';
+
+		return $url . $separator . $query;
 	}
 
 	/**

--- a/secure-oidc-login.php
+++ b/secure-oidc-login.php
@@ -53,6 +53,7 @@ if ( ! class_exists( 'Firebase\JWT\JWT' ) ) {
 	}
 }
 
+require_once SECURE_OIDC_LOGIN_PLUGIN_DIR . 'includes/class-oidc-url.php';
 require_once SECURE_OIDC_LOGIN_PLUGIN_DIR . 'includes/class-oidc-client.php';
 require_once SECURE_OIDC_LOGIN_PLUGIN_DIR . 'includes/class-oidc-state-binding.php';
 require_once SECURE_OIDC_LOGIN_PLUGIN_DIR . 'includes/class-oidc-admin.php';
@@ -1019,11 +1020,6 @@ class Secure_OIDC_Login {
 	/**
 	 * Append query parameters to a URL that may already contain a query string.
 	 *
-	 * Some providers (e.g. Azure AD B2C) require a policy parameter on their
-	 * authorization and end-session endpoints, so the configured endpoint can
-	 * already carry a query string. Appending with a literal '?' would corrupt
-	 * the resulting URL.
-	 *
 	 * @since 1.3.2
 	 *
 	 * @param string              $url    The endpoint URL.
@@ -1031,15 +1027,7 @@ class Secure_OIDC_Login {
 	 * @return string The URL with parameters appended.
 	 */
 	private function build_query_url( string $url, array $params ): string {
-		$query = http_build_query( $params );
-
-		if ( '' === $query ) {
-			return $url;
-		}
-
-		$separator = str_contains( $url, '?' ) ? '&' : '?';
-
-		return $url . $separator . $query;
+		return OIDC_Url::build_query_url( $url, $params );
 	}
 
 	/**

--- a/tests/Unit/Url/OIDCUrlTest.php
+++ b/tests/Unit/Url/OIDCUrlTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Tests for OIDC_Url class.
+ *
+ * @package SecureOIDCLogin\Tests\Unit\Url
+ */
+
+declare(strict_types=1);
+
+namespace SecureOIDCLogin\Tests\Unit\Url;
+
+use OIDC_Url;
+use SecureOIDCLogin\Tests\OIDCTestCase;
+
+/**
+ * Tests for the query URL builder helper.
+ *
+ * @covers OIDC_Url
+ */
+class OIDCUrlTest extends OIDCTestCase
+{
+    /**
+     * A plain endpoint without a query string gets parameters appended with '?'.
+     */
+    public function testAppendsWithQuestionMarkWhenUrlHasNoQueryString(): void
+    {
+        $url = 'https://idp.example.com/authorize';
+
+        $result = OIDC_Url::build_query_url($url, ['response_type' => 'code']);
+
+        $this->assertSame('https://idp.example.com/authorize?response_type=code', $result);
+    }
+
+    /**
+     * An endpoint that already carries a query string (e.g. Azure AD B2C policy)
+     * gets parameters appended with '&', not a second '?'.
+     */
+    public function testAppendsWithAmpersandWhenUrlAlreadyHasQueryString(): void
+    {
+        $url = 'https://tenant.b2clogin.com/tenant.onmicrosoft.com/oauth2/v2.0/authorize?p=B2C_1_signin';
+
+        $result = OIDC_Url::build_query_url($url, ['response_type' => 'code']);
+
+        $this->assertSame(
+            'https://tenant.b2clogin.com/tenant.onmicrosoft.com/oauth2/v2.0/authorize?p=B2C_1_signin&response_type=code',
+            $result
+        );
+    }
+
+    /**
+     * Empty params leave the URL unchanged (no dangling separator).
+     */
+    public function testEmptyParamsReturnUrlUnchanged(): void
+    {
+        $url = 'https://idp.example.com/logout';
+
+        $this->assertSame($url, OIDC_Url::build_query_url($url, []));
+    }
+
+    /**
+     * Empty params on a URL that has a query string also leave it unchanged.
+     */
+    public function testEmptyParamsOnUrlWithQueryStringReturnUrlUnchanged(): void
+    {
+        $url = 'https://idp.example.com/logout?p=policy';
+
+        $this->assertSame($url, OIDC_Url::build_query_url($url, []));
+    }
+
+    /**
+     * Parameter values are urlencoded via http_build_query().
+     */
+    public function testParameterValuesAreUrlEncoded(): void
+    {
+        $url = 'https://idp.example.com/authorize';
+
+        $result = OIDC_Url::build_query_url($url, [
+            'redirect_uri' => 'https://wp.example.com/wp-login.php?oidc_callback=1',
+            'scope'        => 'openid email profile',
+        ]);
+
+        $this->assertSame(
+            'https://idp.example.com/authorize?redirect_uri=https%3A%2F%2Fwp.example.com%2Fwp-login.php%3Foidc_callback%3D1&scope=openid+email+profile',
+            $result
+        );
+    }
+
+    /**
+     * Multiple parameters preserve their order, appending to an existing query string.
+     */
+    public function testMultipleParametersPreserveOrder(): void
+    {
+        $url = 'https://idp.example.com/logout?p=B2C_1_logout';
+
+        $result = OIDC_Url::build_query_url($url, [
+            'id_token_hint' => 'token-value',
+            'client_id'     => 'client-123',
+        ]);
+
+        $this->assertSame(
+            'https://idp.example.com/logout?p=B2C_1_logout&id_token_hint=token-value&client_id=client-123',
+            $result
+        );
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -68,6 +68,7 @@ require_once __DIR__ . '/stubs/class-wp-session-tokens.php';
 require_once __DIR__ . '/stubs/class-secure-oidc-login.php';
 
 // Load plugin class files
+require_once dirname(__DIR__) . '/includes/class-oidc-url.php';
 require_once dirname(__DIR__) . '/includes/class-oidc-token-crypto.php';
 require_once dirname(__DIR__) . '/includes/class-oidc-admin.php';
 require_once dirname(__DIR__) . '/includes/class-oidc-client.php';


### PR DESCRIPTION
## Summary

Fixes #71.

`initiate_login()` and `handle_logout()` built IdP URLs by concatenating a literal `?`. When the configured endpoint already contains a query string (e.g. Azure AD B2C policy parameters like `.../authorize?p=B2C_1_signin`), this produced URLs with two `?` characters, corrupting the authorization request and RP-initiated logout.

## Changes

- Add `Secure_OIDC_Login::build_query_url()`, which appends parameters with `?` or `&` depending on whether the endpoint already contains a query string. Parameters are still encoded via `http_build_query()` (avoiding the encoding caveats of `add_query_arg`).
- Use it for both the authorization URL (`initiate_login()`) and the end-session URL (`handle_logout()`).

## Testing

- `phpcs` passes on the modified file.
- Full unit suite passes: 484 tests, 1124 assertions.
- Note: `build_query_url()` lives in the main plugin file, which is not loaded by the PHPUnit bootstrap (a stub class is used instead), so it isn't directly covered by a unit test without restructuring the test harness. Happy to add that as follow-up if desired.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization and logout URL handling when endpoints already include query parameters.
  * Prevented unnecessary query separators when no additional parameters are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->