### PR TITLE
fix: only count invalid back-channel logout tokens toward rate limit

### DIFF
--- a/includes/class-oidc-client.php
+++ b/includes/class-oidc-client.php
@@ -798,22 +798,20 @@ class OIDC_Client {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			return $this->handle_error(
-				'jwks_fetch',
-				'Failed to fetch JWKS: ' . $response->get_error_message(),
-				__( 'Authentication configuration error. Please contact the site administrator.', 'secure-oidc-login' )
-			);
+			error_log( sprintf( 'OIDC Error [jwks_fetch]: Failed to fetch JWKS: %s', $response->get_error_message() ) );
+			// Distinct error code so callers can distinguish infrastructure failures
+			// from invalid tokens (e.g. back-channel logout rate limiting).
+			return new WP_Error( 'jwks_fetch', __( 'Authentication configuration error. Please contact the site administrator.', 'secure-oidc-login' ) );
 		}
 
 		$status_code = (int) wp_remote_retrieve_response_code( $response );
 
 		// If the sever returns anthing other than OK, retun an error.
 		if ( 200 !== $status_code ) {
-			return $this->handle_error(
-				'jwks_fetch',
-				'Failed to fetch JWKS. HTTP status: ' . $status_code,
-				__( 'Authentication configuration error. Please contact the site administrator.', 'secure-oidc-login' )
-			);
+			error_log( sprintf( 'OIDC Error [jwks_fetch]: Failed to fetch JWKS. HTTP status: %d', $status_code ) );
+			// Distinct error code so callers can distinguish infrastructure failures
+			// from invalid tokens (e.g. back-channel logout rate limiting).
+			return new WP_Error( 'jwks_fetch', __( 'Authentication configuration error. Please contact the site administrator.', 'secure-oidc-login' ) );
 		}
 
 		$body = wp_remote_retrieve_body( $response );

--- a/includes/class-oidc-client.php
+++ b/includes/class-oidc-client.php
@@ -721,10 +721,13 @@ class OIDC_Client {
 			// but our cached JWKS still contains only the old key. Retry once with fresh JWKS to handle this.
 			if ( $retry ) {
 				$fresh_jwks = $this->get_jwks( true );
-				if ( ! is_wp_error( $fresh_jwks ) ) {
-					// Retry decode with fresh JWKS (retry=false prevents infinite loop)
-					return $this->decode_and_verify_jwt( $jwt, false );
+				if ( is_wp_error( $fresh_jwks ) ) {
+					// Propagate infrastructure failures (e.g. 'jwks_fetch') so callers can
+					// distinguish IdP outages from invalid tokens.
+					return $fresh_jwks;
 				}
+				// Retry decode with fresh JWKS (retry=false prevents infinite loop)
+				return $this->decode_and_verify_jwt( $jwt, false );
 			}
 			return new WP_Error( 'oidc_error', __( 'ID token signature verification failed.', 'secure-oidc-login' ) );
 
@@ -819,7 +822,8 @@ class OIDC_Client {
 
 		// Ensure the JWKS response is valid and contains a "keys" array per RFC 7517 Section 5.
 		if ( ! $jwks || ! isset( $jwks['keys'] ) || ! is_array( $jwks['keys'] ) ) {
-			return new WP_Error( 'oidc_error', __( 'Invalid JWKS response.', 'secure-oidc-login' ) );
+			error_log( 'OIDC Error [jwks_fetch]: Invalid JWKS response.' );
+			return new WP_Error( 'jwks_fetch', __( 'Authentication configuration error. Please contact the site administrator.', 'secure-oidc-login' ) );
 		}
 
 		// Cache the JWKS with integrity protection

--- a/includes/class-oidc-rest-controller.php
+++ b/includes/class-oidc-rest-controller.php
@@ -116,7 +116,6 @@ class OIDC_REST_Controller extends WP_REST_Controller {
 		if ( $this->rate_limiter->is_rate_limited( 'backchannel_logout' ) ) {
 			return $this->backchannel_response( array( 'error' => 'invalid_request' ), 400 );
 		}
-		$this->rate_limiter->record_attempt( 'backchannel_logout' );
 
 		// The SECURE_OIDC_ENABLE_BACKCHANNEL_LOGOUT environment variable overrides the
 		// stored setting, matching how the admin UI presents env-managed checkboxes
@@ -137,12 +136,18 @@ class OIDC_REST_Controller extends WP_REST_Controller {
 
 		$logout_token = $request->get_param( 'logout_token' );
 		if ( ! is_string( $logout_token ) || '' === $logout_token ) {
+			$this->rate_limiter->record_attempt( 'backchannel_logout' );
 			return $this->backchannel_response( array( 'error' => 'invalid_request' ), 400 );
 		}
 
 		$result = $this->get_backchannel_handler()->handle_logout_token( $logout_token );
 
 		if ( is_wp_error( $result ) ) {
+			// SECURITY: Only invalid tokens accumulate toward the rate limit. Valid
+			// tokens are not counted, so an IdP performing bulk revocation (admin
+			// force-logout, incident response) cannot self-throttle and leave
+			// sessions alive past IdP revocation.
+			$this->rate_limiter->record_attempt( 'backchannel_logout' );
 			return $this->backchannel_response( array( 'error' => 'invalid_request' ), 400 );
 		}
 

--- a/includes/class-oidc-rest-controller.php
+++ b/includes/class-oidc-rest-controller.php
@@ -91,7 +91,10 @@ class OIDC_REST_Controller extends WP_REST_Controller {
 				'permission_callback' => '__return_true',
 				'args'                => array(
 					'logout_token' => array(
-						'required'    => true,
+						// Not marked required: an absent parameter must reach the callback so
+						// it is answered with the spec's invalid_request body and counted by
+						// the rate limiter, instead of WordPress' generic missing-param error.
+						'required'    => false,
 						'type'        => 'string',
 						'description' => __( 'The signed OIDC logout token (JWT).', 'secure-oidc-login' ),
 					),
@@ -146,8 +149,12 @@ class OIDC_REST_Controller extends WP_REST_Controller {
 			// SECURITY: Only invalid tokens accumulate toward the rate limit. Valid
 			// tokens are not counted, so an IdP performing bulk revocation (admin
 			// force-logout, incident response) cannot self-throttle and leave
-			// sessions alive past IdP revocation.
-			$this->rate_limiter->record_attempt( 'backchannel_logout' );
+			// sessions alive past IdP revocation. Infrastructure failures fetching the
+			// JWKS are also not counted: they are not attacker-controlled and would
+			// lock out valid revocations during a provider outage.
+			if ( 'jwks_fetch' !== $result->get_error_code() ) {
+				$this->rate_limiter->record_attempt( 'backchannel_logout' );
+			}
 			return $this->backchannel_response( array( 'error' => 'invalid_request' ), 400 );
 		}
 

--- a/tests/Unit/Client/OIDCClientTest.php
+++ b/tests/Unit/Client/OIDCClientTest.php
@@ -1964,6 +1964,68 @@ class OIDCClientTest extends OIDCTestCase
     }
 
     /**
+     * Test decode_and_verify_jwt propagates the jwks_fetch error from a failed
+     * forced refresh after a signature failure.
+     *
+     * Key-rotation retry path: the first signature verification fails, the client
+     * force-refreshes the JWKS, and if that fetch fails the infrastructure error
+     * must propagate (not be masked as a generic signature failure) so callers can
+     * distinguish IdP outages from invalid tokens.
+     */
+    public function testDecodeAndVerifyJwtPropagatesJwksErrorOnForcedRefreshFailure(): void
+    {
+        // Generate two real RSA keys: sign with A, publish B in the JWKS, so
+        // verification genuinely fails as SignatureInvalidException.
+        $resA = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+        openssl_pkey_export($resA, $privateKeyA);
+        $resB = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+        $detailsB = openssl_pkey_get_details($resB);
+
+        $b64url = static fn (string $bytes) => rtrim(strtr(base64_encode($bytes), '+/', '-_'), '=');
+
+        $jwks = ['keys' => [
+            [
+                'kty' => 'RSA',
+                'kid' => 'test-key',
+                'alg' => 'RS256',
+                'use' => 'sig',
+                'n'   => $b64url($detailsB['rsa']['n']),
+                'e'   => $b64url($detailsB['rsa']['e']),
+            ],
+        ]];
+
+        // First fetch (initial JWKS load) succeeds; the forced refresh fails.
+        $calls = 0;
+        Functions\when('get_transient')->justReturn(false);
+        Functions\when('wp_safe_remote_get')->alias(function () use (&$calls, $jwks) {
+            $calls++;
+            if (1 === $calls) {
+                return ['body' => json_encode($jwks), 'response' => ['code' => 200]];
+            }
+            return new WP_Error('http_error', 'Connection failed');
+        });
+        Functions\when('is_wp_error')->alias(fn($thing) => $thing instanceof WP_Error);
+        Functions\when('set_transient')->justReturn(true);
+        Functions\when('wp_json_encode')->alias(fn($data) => json_encode($data));
+
+        // Build a genuine RS256 JWT signed with key A while the JWKS publishes key B.
+        // The header carries the kid so JWT::decode can select the verification key.
+        $header = $b64url(json_encode(['alg' => 'RS256', 'typ' => 'JWT', 'kid' => 'test-key']));
+        $payload = $b64url(json_encode(['sub' => 'test']));
+        $signingInput = "$header.$payload";
+        openssl_sign($signingInput, $signatureBytes, $privateKeyA, OPENSSL_ALGO_SHA256);
+        $jwt = "$signingInput." . $b64url($signatureBytes);
+
+        $reflection = new \ReflectionMethod(OIDC_Client::class, 'decode_and_verify_jwt');
+        $reflection->setAccessible(true);
+
+        $result = $reflection->invoke($this->client, $jwt);
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('jwks_fetch', $result->get_error_code());
+    }
+
+    /**
      * Test decode_and_verify_jwt handles JWKS keys without 'alg' field.
      *
      * Some IdPs omit the 'alg' field in JWKS keys. The client should

--- a/tests/Unit/Client/OIDCClientTest.php
+++ b/tests/Unit/Client/OIDCClientTest.php
@@ -781,7 +781,7 @@ class OIDCClientTest extends OIDCTestCase
         $result = $method->invoke($this->client);
 
         $this->assertInstanceOf(WP_Error::class, $result);
-        $this->assertStringContainsString('Invalid JWKS response', $result->get_error_message());
+        $this->assertSame('jwks_fetch', $result->get_error_code());
     }
 
     /**

--- a/tests/Unit/REST/OIDCRestControllerTest.php
+++ b/tests/Unit/REST/OIDCRestControllerTest.php
@@ -722,7 +722,9 @@ class OIDCRestControllerTest extends OIDCTestCase
 
         // Authenticated by the signed logout token, not a WP session
         $this->assertSame('__return_true', $args['permission_callback']);
-        $this->assertTrue($args['args']['logout_token']['required']);
+        // Not required: absent params must reach the callback so they are counted
+        // by the rate limiter and answered with the spec's invalid_request body.
+        $this->assertFalse($args['args']['logout_token']['required']);
     }
 
     /**
@@ -1246,5 +1248,61 @@ class OIDCRestControllerTest extends OIDCTestCase
 
         $this->assertSame(400, $result->get_status());
         $this->assertCount(1, $recorded, 'An invalid logout token must record a rate-limit attempt.');
+    }
+
+    /**
+     * Test an absent logout_token reaches the callback and is counted.
+     *
+     * The route argument is deliberately not required: WordPress would otherwise
+     * reject the request pre-dispatch with rest_missing_callback_param, bypassing
+     * rate-limit accounting entirely.
+     */
+    public function testBackchannelLogoutAbsentTokenRecordsAttempt(): void
+    {
+        Functions\when('get_option')->justReturn(['enable_backchannel_logout' => true]);
+
+        $recorded = [];
+        Functions\when('set_transient')->alias(static function ($key, $value) use (&$recorded) {
+            if (str_contains((string) $key, 'backchannel')) {
+                $recorded[] = $key;
+            }
+            return true;
+        });
+
+        [$controller, $request] = $this->buildBackchannelScenario(null, null);
+
+        $result = $controller->backchannel_logout($request);
+
+        $this->assertSame(400, $result->get_status());
+        $this->assertCount(1, $recorded, 'A request without logout_token must record a rate-limit attempt.');
+    }
+
+    /**
+     * Test a JWKS infrastructure failure does not count toward the rate limit.
+     *
+     * A JWKS fetch failure is not attacker-controlled; counting it would lock out
+     * valid revocations during a provider outage and leave sessions alive.
+     */
+    public function testBackchannelLogoutJwksFailureDoesNotRecordAttempt(): void
+    {
+        Functions\when('get_option')->justReturn(['enable_backchannel_logout' => true]);
+
+        $recorded = [];
+        Functions\when('set_transient')->alias(static function ($key, $value) use (&$recorded) {
+            if (str_contains((string) $key, 'backchannel')) {
+                $recorded[] = $key;
+            }
+            return true;
+        });
+
+        [$controller, $request] = $this->buildBackchannelScenario(
+            new WP_Error('jwks_fetch', 'Authentication configuration error.'),
+            'valid.logout.token'
+        );
+
+        $result = $controller->backchannel_logout($request);
+
+        $this->assertSame(400, $result->get_status());
+        $this->assertSame([], $recorded, 'A JWKS infrastructure failure must not record a rate-limit attempt.');
     }
 }

--- a/tests/Unit/REST/OIDCRestControllerTest.php
+++ b/tests/Unit/REST/OIDCRestControllerTest.php
@@ -1194,4 +1194,57 @@ class OIDCRestControllerTest extends OIDCTestCase
 
         $this->assertSame(400, $result->get_status());
     }
+
+    /**
+     * Test a successfully validated logout token does not count toward the rate limit.
+     *
+     * Regression test for issue #72: an IdP performing bulk revocation sends many
+     * valid tokens from one IP; counting them would lock out legitimate traffic and
+     * leave sessions alive past IdP revocation. Only invalid tokens may accumulate.
+     */
+    public function testBackchannelLogoutSuccessDoesNotRecordAttempt(): void
+    {
+        Functions\when('get_option')->justReturn(['enable_backchannel_logout' => true]);
+
+        $recorded = [];
+        Functions\when('set_transient')->alias(static function ($key, $value) use (&$recorded) {
+            if (str_contains((string) $key, 'backchannel')) {
+                $recorded[] = $key;
+            }
+            return true;
+        });
+
+        [$controller, $request] = $this->buildBackchannelScenario(true, 'valid.logout.token');
+
+        $result = $controller->backchannel_logout($request);
+
+        $this->assertSame(200, $result->get_status());
+        $this->assertSame([], $recorded, 'A valid logout token must not record a rate-limit attempt.');
+    }
+
+    /**
+     * Test an invalid logout token still counts toward the rate limit.
+     */
+    public function testBackchannelLogoutInvalidTokenRecordsAttempt(): void
+    {
+        Functions\when('get_option')->justReturn(['enable_backchannel_logout' => true]);
+
+        $recorded = [];
+        Functions\when('set_transient')->alias(static function ($key, $value) use (&$recorded) {
+            if (str_contains((string) $key, 'backchannel')) {
+                $recorded[] = $key;
+            }
+            return true;
+        });
+
+        [$controller, $request] = $this->buildBackchannelScenario(
+            new WP_Error('oidc_error', 'Invalid logout token issuer.'),
+            'forged.logout.token'
+        );
+
+        $result = $controller->backchannel_logout($request);
+
+        $this->assertSame(400, $result->get_status());
+        $this->assertCount(1, $recorded, 'An invalid logout token must record a rate-limit attempt.');
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #72.

The back-channel logout endpoint recorded a rate-limit attempt for **every** request and never cleared the counter on success. With the defaults (10 attempts / 5 minutes, 15-minute lockout), an IdP performing bulk revocation — admin force-logout, session sweep, incident response — locked itself out after the tenth token, and validly signed logout tokens were then rejected with `400`, leaving WordPress sessions alive past IdP revocation.

## Changes

`backchannel_logout()` now records a rate-limit attempt **only when token validation fails**:

- Missing/empty `logout_token` → counted (still brute-force relevant).
- `handle_logout_token()` returns `WP_Error` → counted.
- Successfully validated token → not counted, so legitimate server-to-server bulk traffic is never throttled.

The limiter still serves its original purpose: invalid-token floods from any single IP hit the lockout exactly as before, and lockout checks still run before any validation work.

## Testing

- New regression tests:
  - Valid token → 200 and no attempt recorded.
  - Invalid token → 400 and attempt recorded.
- Existing rate-limit test (lockout → 400) still passes.
- phpcs clean; full suite: 492 tests, 1136 assertions, all passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Back-channel logout requests without tokens now receive the correct invalid-request response.
  * Missing, empty, or invalid logout tokens are recorded for rate limiting.
  * Valid logout requests and JWKS retrieval failures are excluded from rate-limit counts.
  * JWKS retrieval errors now provide clearer diagnostic logging while preserving user-facing error messages.
  * JWKS refresh failures during token verification are now reported accurately.

* **Tests**
  * Added coverage for missing tokens, valid tokens, invalid tokens, and JWKS retrieval failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->