### PR TITLE
fix: fail gracefully when state-scoped transients expire mid-callback

### DIFF
--- a/secure-oidc-login.php
+++ b/secure-oidc-login.php
@@ -697,6 +697,14 @@ class Secure_OIDC_Login {
 		delete_transient( 'oidc_code_verifier_' . $state );
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
+		// get_transient() returns false when the transient expired or was evicted
+		// (e.g. memcached LRU). Under strict types, passing false to exchange_code()'s
+		// ?string parameter would throw an uncaught TypeError; fail gracefully instead.
+		if ( ! is_string( $code_verifier ) || '' === $code_verifier ) {
+			$this->handle_error( __( 'Login session expired. Please try again.', 'secure-oidc-login' ) );
+			return;
+		}
+
 		// Exchange authorization code for access/ID tokens
 		$tokens = $this->client->exchange_code( $code, $code_verifier );
 
@@ -705,8 +713,14 @@ class Secure_OIDC_Login {
 			return;
 		}
 
-		// Retrieve nonce before validation
+		// Retrieve nonce before validation. A missing transient must fail explicitly:
+		// passing null would skip nonce validation entirely in validate_id_token(),
+		// so this check keeps replay protection fail-closed.
 		$nonce = get_transient( 'oidc_nonce_' . $state );
+		if ( ! is_string( $nonce ) || '' === $nonce ) {
+			$this->handle_error( __( 'Login session expired. Please try again.', 'secure-oidc-login' ) );
+			return;
+		}
 
 		// Validate ID token claims (issuer, audience, expiration) and nonce
 		$id_token_claims = $this->client->validate_id_token( $tokens['id_token'], $nonce, $code, $tokens['access_token'] );


### PR DESCRIPTION
## Summary

Fixes #73.

`handle_callback()` passed raw `get_transient()` results into `?string` parameters under `declare(strict_types=1)`. When a state-scoped transient expired or was evicted (TTL boundary, memcached LRU), `false` reached `exchange_code()` / `validate_id_token()` and threw an uncaught `TypeError` — an HTTP 500 / white screen instead of the graceful `oidc_error` redirect every other failure path provides.

## Changes

- **Missing code verifier** (`oidc_code_verifier_{state}` transient is `false`/empty): route through `handle_error()` with a "Login session expired" message and return — same UX as every other callback failure.
- **Missing nonce** (`oidc_nonce_{state}` transient is `false`/empty): fail explicitly via `handle_error()`. This is deliberate: passing `null` would make `validate_id_token()` **skip** nonce validation entirely, so the strict-types crash was previously the only thing keeping this path fail-closed. The explicit check preserves replay protection without the fatal error.

## Testing

- phpcs clean; full suite passes (495 tests, 1144 assertions).
- Note: `handle_callback()` lives in the main plugin file, which the PHPUnit bootstrap replaces with a stub class, so it isn't directly unit-testable without restructuring the harness (same limitation noted in #84). The change is a straight guard clause on two `get_transient()` reads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in reliability when authorization sessions expire or required security values are unavailable.
  * Users are now redirected with a clear session-expired error instead of encountering a failure or incomplete security validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->