### PR TITLE
fix: require iat and exp claims in ID tokens

### DIFF
--- a/includes/class-oidc-client.php
+++ b/includes/class-oidc-client.php
@@ -351,6 +351,13 @@ class OIDC_Client {
 			return new WP_Error( 'oidc_error', __( 'Missing required sub claim in ID token.', 'secure-oidc-login' ) );
 		}
 
+		// iat and exp are REQUIRED claims in ID tokens (OIDC Core Section 2); the JWT
+		// library only enforces them when present, so require them explicitly. Without
+		// this check a token without exp would never expire.
+		if ( ! isset( $claims['iat'] ) || ! isset( $claims['exp'] ) ) {
+			return new WP_Error( 'oidc_error', __( 'ID token is missing required iat or exp claim.', 'secure-oidc-login' ) );
+		}
+
 		// Verify the token was issued by the expected IdP (OIDC Core spec 3.1.3.7)
 		// If we are missing the issuer in settings, fail since there is nothing to compare against.
 		$issuer = $this->get_setting( 'issuer' );

--- a/tests/Unit/Client/OIDCClientTest.php
+++ b/tests/Unit/Client/OIDCClientTest.php
@@ -404,6 +404,45 @@ class OIDCClientTest extends OIDCTestCase
     }
 
     /**
+     * Test validate_id_token rejects a token missing the required exp claim.
+     *
+     * The JWT library only enforces exp when present (OIDC Core Section 2 makes it
+     * REQUIRED); without this check a token without exp would never expire.
+     */
+    public function testValidateIdTokenRejectsMissingExpClaim(): void
+    {
+        $client = $this->createClientWithStubbedJwt([
+            'sub' => 'user-123',
+            'iss' => 'https://idp.example.com',
+            'aud' => 'test-client-id',
+            'exp' => null, // override stub default: claim absent
+        ]);
+
+        $result = $client->validate_id_token('fake.jwt.token');
+
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertStringContainsString('iat or exp', $result->get_error_message());
+    }
+
+    /**
+     * Test validate_id_token rejects a token missing the required iat claim.
+     */
+    public function testValidateIdTokenRejectsMissingIatClaim(): void
+    {
+        $client = $this->createClientWithStubbedJwt([
+            'sub' => 'user-123',
+            'iss' => 'https://idp.example.com',
+            'aud' => 'test-client-id',
+            'iat' => null, // override stub default: claim absent
+        ]);
+
+        $result = $client->validate_id_token('fake.jwt.token');
+
+        $this->assertInstanceOf(\WP_Error::class, $result);
+        $this->assertStringContainsString('iat or exp', $result->get_error_message());
+    }
+
+    /**
      * Test exchange_code includes PKCE code_verifier parameter when provided.
      */
     public function testExchangeCodeIncludesPkceCodeVerifier(): void
@@ -2532,7 +2571,12 @@ class OIDCClientTest extends OIDCTestCase
 
             protected function decode_and_verify_jwt(string $jwt, bool $retry = true): array|\WP_Error
             {
-                return array_merge(['__jwt_alg' => 'RS256'], $this->stubbedClaims);
+                // Default iat/exp mirror a well-formed token; tests targeting the
+                // required-claim check override them with null.
+                return array_merge(
+                    ['__jwt_alg' => 'RS256', 'iat' => time(), 'exp' => time() + 300],
+                    $this->stubbedClaims
+                );
             }
         };
     }
@@ -3226,15 +3270,15 @@ class OIDCClientTest extends OIDCTestCase
      */
     public function testValidateLogoutTokenRejectsMissingRequiredClaims(): void
     {
-        // Missing exp
+        // Missing exp (explicit null: isset(null) is false, so the claim counts as absent)
         $claims = $this->getSampleLogoutTokenClaims();
-        unset($claims['exp']);
+        $claims['exp'] = null;
         $result = $this->createClientWithStubbedJwt($claims)->validate_logout_token('h.p.s');
         $this->assertInstanceOf(WP_Error::class, $result);
 
         // Missing jti
         $claims = $this->getSampleLogoutTokenClaims();
-        unset($claims['jti']);
+        $claims['jti'] = null;
         $result = $this->createClientWithStubbedJwt($claims)->validate_logout_token('h.p.s');
         $this->assertInstanceOf(WP_Error::class, $result);
         $this->assertStringContainsString('jti', $result->get_error_message());

--- a/tests/Unit/Client/OIDCClientTest.php
+++ b/tests/Unit/Client/OIDCClientTest.php
@@ -404,40 +404,30 @@ class OIDCClientTest extends OIDCTestCase
     }
 
     /**
-     * Test validate_id_token rejects a token missing the required exp claim.
+     * Test validate_id_token rejects tokens missing the required iat/exp claims.
      *
-     * The JWT library only enforces exp when present (OIDC Core Section 2 makes it
-     * REQUIRED); without this check a token without exp would never expire.
+     * The JWT library only enforces exp when present (OIDC Core Section 2 makes both
+     * claims REQUIRED); without this check a token without exp would never expire.
      */
-    public function testValidateIdTokenRejectsMissingExpClaim(): void
+    public function testValidateIdTokenRejectsMissingRequiredClaims(): void
     {
-        $client = $this->createClientWithStubbedJwt([
+        $base = static fn (): array => [
             'sub' => 'user-123',
             'iss' => 'https://idp.example.com',
             'aud' => 'test-client-id',
-            'exp' => null, // override stub default: claim absent
-        ]);
+        ];
 
-        $result = $client->validate_id_token('fake.jwt.token');
-
+        // Missing exp
+        $claims = $base();
+        $claims['exp'] = null; // override stub default: claim absent
+        $result = $this->createClientWithStubbedJwt($claims)->validate_id_token('h.p.s');
         $this->assertInstanceOf(\WP_Error::class, $result);
         $this->assertStringContainsString('iat or exp', $result->get_error_message());
-    }
 
-    /**
-     * Test validate_id_token rejects a token missing the required iat claim.
-     */
-    public function testValidateIdTokenRejectsMissingIatClaim(): void
-    {
-        $client = $this->createClientWithStubbedJwt([
-            'sub' => 'user-123',
-            'iss' => 'https://idp.example.com',
-            'aud' => 'test-client-id',
-            'iat' => null, // override stub default: claim absent
-        ]);
-
-        $result = $client->validate_id_token('fake.jwt.token');
-
+        // Missing iat
+        $claims = $base();
+        $claims['iat'] = null; // override stub default: claim absent
+        $result = $this->createClientWithStubbedJwt($claims)->validate_id_token('h.p.s');
         $this->assertInstanceOf(\WP_Error::class, $result);
         $this->assertStringContainsString('iat or exp', $result->get_error_message());
     }


### PR DESCRIPTION
## Summary

Fixes #74.

`validate_id_token()` did not require the `exp`/`iat` claims. The Firebase JWT library only enforces those claims **when present**, so an ID token without `exp` passed validation and was effectively non-expiring. `validate_logout_token()` already closed this gap for logout tokens; this applies the same treatment to ID tokens, per OIDC Core §2 (both claims REQUIRED) and §3.1.3.7 step 9.

## Changes

- `validate_id_token()` rejects tokens missing `iat` or `exp` (check placed immediately after the required-`sub` check).
- Test stub (`createClientWithStubbedJwt`) now defaults `iat`/`exp` to well-formed values so existing tests keep exercising their own logic; tests targeting claim absence pass explicit `null`.
- New tests: missing `exp` rejected, missing `iat` rejected.
- Updated `testValidateLogoutTokenRejectsMissingRequiredClaims` to use explicit nulls instead of `unset` (the stub default would otherwise re-add the key).

## Testing

- Full suite: 497 tests, 1148 assertions, all passing; phpcs clean.
