### PR TITLE
ci: add AI-powered automatic PR review agent

### DIFF
--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -26,6 +26,17 @@ Optional:
                         spend these on thinking first, so go higher if truncated)
   AI_TIMEOUT            Socket read timeout in seconds (default 600). With streaming
                         on, this is per-chunk, not total, so it rarely needs raising.
+  AI_BACKEND            "api" (default) posts the diff to /chat/completions directly.
+                        "opencode" runs `opencode run` headlessly inside the repo
+                        checkout with a read-only agent, so the model can read the
+                        code around the diff. Requires opencode on PATH and a full
+                        checkout (fetch-depth: 0). Ponytail loads as the native
+                        OpenCode plugin instead of an inlined ruleset.
+  AI_AGENT_TIMEOUT      Seconds allowed for the whole opencode run (default 1500).
+  AI_JSON_MODE          "true" (default) sends response_format=json_object. Set
+                        "false" for reasoning models that stop dead under JSON
+                        mode (Poolside Laguna does); the script auto-detects and
+                        retries without it, but opting out saves a wasted pass.
   AI_STREAM             "true" (default) streams the response, which keeps the
                         connection alive while a reasoning model thinks and avoids
                         gateway idle timeouts. Set "false" for providers that
@@ -168,17 +179,24 @@ def fetch_ponytail(ref: str) -> str:
     return "\n\n".join(parts)
 
 
-def build_system_prompt(ponytail_mode: str, ponytail_ref: str, extra: str) -> str:
-    """ponytail_mode: 'off' (default), 'on' (hybrid), or 'only'."""
+def build_system_prompt(ponytail_mode: str, ponytail_ref: str, extra: str, inline_ruleset: bool = True) -> str:
+    """ponytail_mode: 'off' (default), 'on' (hybrid), or 'only'.
+    inline_ruleset=False when a harness plugin already injects Ponytail every turn."""
     if ponytail_mode == "off":
         prompt = CORRECTNESS_PROMPT + COMMON_RULES + OUTPUT_SCHEMA
     else:
-        try:
-            ruleset = fetch_ponytail(ponytail_ref)
-        except Exception as e:
-            log(f"::warning::Ponytail requested but could not be loaded ({e}); falling back to standard review")
-            ponytail_mode = "off"
-            ruleset = ""
+        if not inline_ruleset:
+            ruleset = (
+                "The Ponytail plugin is active in this session and its ruleset is injected on every turn. "
+                "Apply the `ponytail-review` skill format for over-engineering findings."
+            )
+        else:
+            try:
+                ruleset = fetch_ponytail(ponytail_ref)
+            except Exception as e:
+                log(f"::warning::Ponytail requested but could not be loaded ({e}); falling back to standard review")
+                ponytail_mode = "off"
+                ruleset = ""
         if ponytail_mode == "only":
             prompt = (
                 "You are a senior software engineer reviewing a GitHub pull request.\n"
@@ -468,6 +486,7 @@ def call_model(
     timeout: int = 600,
     extra_body: dict | None = None,
     stream: bool = True,
+    json_mode: bool = True,
 ) -> str:
     url = base_url.rstrip("/") + "/chat/completions"
     headers = {
@@ -484,8 +503,9 @@ def call_model(
             {"role": "system", "content": system},
             {"role": "user", "content": user},
         ],
-        "response_format": {"type": "json_object"},
     }
+    if json_mode:
+        payload["response_format"] = {"type": "json_object"}
     if stream:
         # Streaming keeps the connection alive while a reasoning model thinks, so
         # gateway idle timeouts don't kill long requests.
@@ -573,6 +593,154 @@ def call_model(
     return content
 
 
+
+# --------------------------------------------------------------------------- #
+# OpenCode backend
+# --------------------------------------------------------------------------- #
+
+# Read-only tool policy for the review agent. OpenCode evaluates rules by pattern
+# with last-match-wins, so the "*" deny goes first and allowances follow.
+READ_ONLY_BASH = {
+    "*": "deny",
+    "git diff*": "allow",
+    "git log*": "allow",
+    "git show*": "allow",
+    "git status*": "allow",
+    "git blame*": "allow",
+    "git ls-files*": "allow",
+    "grep *": "allow",
+    "rg *": "allow",
+    "cat *": "allow",
+    "head *": "allow",
+    "tail *": "allow",
+    "ls*": "allow",
+    "find *": "allow",
+    "find * -delete*": "deny",
+    "find * -exec*": "deny",
+    "wc *": "allow",
+    "tree*": "allow",
+    "pwd*": "allow",
+}
+
+
+def write_opencode_config(
+    cfg_dir: str,
+    model: str,
+    base_url: str,
+    system_prompt: str,
+    temperature: float,
+    max_tokens: int,
+    ponytail: bool,
+    extra_body: dict | None,
+) -> str:
+    """Write an isolated opencode.json + system prompt and return the config path.
+    The API key is referenced via {env:AI_API_KEY}, never written to disk."""
+    os.makedirs(cfg_dir, exist_ok=True)
+    prompt_path = os.path.join(cfg_dir, "system.md")
+    with open(prompt_path, "w") as f:
+        f.write(system_prompt)
+
+    model_entry: dict = {
+        "name": model,
+        "limit": {"context": 200000, "output": max_tokens},
+    }
+    if extra_body:
+        # Provider-specific request options (support varies by provider SDK)
+        model_entry["options"] = extra_body
+
+    config: dict = {
+        "$schema": "https://opencode.ai/config.json",
+        "model": f"review/{model}",
+        "share": "disabled",
+        "autoupdate": False,
+        "provider": {
+            "review": {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "PR review endpoint",
+                "options": {"baseURL": base_url, "apiKey": "{env:AI_API_KEY}"},
+                "models": {model: model_entry},
+            }
+        },
+        # Global floor: nothing may write, fetch, or leave the checkout.
+        "permission": {
+            "edit": "deny",
+            "bash": READ_ONLY_BASH,
+            "webfetch": "deny",
+            "websearch": "deny",
+            "external_directory": "deny",
+            "doom_loop": "deny",
+            "read": {"*": "allow", "*.env": "deny", "*.env.*": "deny", "*.pem": "deny", "*.key": "deny"},
+        },
+        "agent": {
+            "reviewer": {
+                "description": "Read-only pull request reviewer",
+                "mode": "primary",
+                "prompt": "{file:" + prompt_path + "}",
+                "temperature": temperature,
+                "permission": {"edit": "deny", "bash": READ_ONLY_BASH, "webfetch": "deny", "websearch": "deny"},
+            }
+        },
+    }
+    if ponytail:
+        config["plugin"] = ["@dietrichgebert/ponytail"]
+
+    cfg_path = os.path.join(cfg_dir, "opencode.json")
+    with open(cfg_path, "w") as f:
+        json.dump(config, f, indent=2)
+    return cfg_path
+
+
+def call_opencode(
+    repo_dir: str,
+    cfg_path: str,
+    model: str,
+    task: str,
+    timeout: int,
+) -> str:
+    """Run `opencode run` headlessly in the checkout and return its stdout."""
+    import shutil
+    import subprocess
+
+    exe = shutil.which("opencode")
+    if not exe:
+        raise RuntimeError("opencode is not on PATH; install it in a prior workflow step")
+
+    # Minimal environment: the agent must not see GITHUB_TOKEN or other CI secrets.
+    env = {
+        k: v for k, v in os.environ.items()
+        if k in ("PATH", "HOME", "LANG", "LC_ALL", "TERM", "AI_API_KEY", "TMPDIR")
+        or k.startswith("XDG_")
+    }
+    env.update({
+        "OPENCODE_CONFIG": cfg_path,
+        "OPENCODE_DISABLE_AUTOUPDATE": "1",
+        "CI": "1",
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_PAGER": "cat",
+        "PAGER": "cat",
+    })
+
+    cmd = [exe, "run", "--agent", "reviewer", "--model", f"review/{model}", task]
+    log(f"Running: opencode run --agent reviewer --model review/{model} <task>")
+    try:
+        proc = subprocess.run(
+            cmd, cwd=repo_dir, env=env, capture_output=True, text=True, timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(f"opencode timed out after {timeout}s") from e
+
+    if proc.stderr.strip():
+        tail = proc.stderr.strip().splitlines()[-30:]
+        log("opencode stderr (tail):\n  " + "\n  ".join(tail))
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"opencode exited {proc.returncode}. stdout tail:\n{proc.stdout[-1500:]}"
+        )
+    if not proc.stdout.strip():
+        raise RuntimeError("opencode produced no output")
+    return proc.stdout
+
+
 def extract_json(text: str) -> dict:
     """Tolerate code fences, leading/trailing prose, <think> blocks, and an
     unterminated reasoning block. Scans for the first balanced {...} that parses."""
@@ -619,6 +787,13 @@ def main() -> int:
     max_tokens = int(env("AI_MAX_TOKENS", "8000"))
     timeout = int(env("AI_TIMEOUT", "600"))
     stream = env("AI_STREAM", "true").strip().lower() not in ("false", "0", "no", "off")
+    json_mode = env("AI_JSON_MODE", "true").strip().lower() not in ("false", "0", "no", "off")
+    backend = env("AI_BACKEND", "api").strip().lower()
+    if backend not in ("api", "opencode"):
+        log(f"::warning::Unknown AI_BACKEND {backend!r}; using 'api'")
+        backend = "api"
+    repo_dir = env("GITHUB_WORKSPACE", os.getcwd())
+    agent_timeout = int(env("AI_AGENT_TIMEOUT", "1500"))
     extra_body: dict = {}
     if env("AI_EXTRA_BODY"):
         try:
@@ -666,24 +841,46 @@ def main() -> int:
     log(f"Reviewing {len(kept)} file(s); excluded {len(skipped_excluded)}, over budget {len(skipped_size)}")
 
     if ponytail_mode != "off":
-        log(f"Ponytail mode: {ponytail_mode} (ref {ponytail_ref})")
-    system = build_system_prompt(ponytail_mode, ponytail_ref, extra_instructions)
+        log(f"Ponytail mode: {ponytail_mode}" + (f" (ref {ponytail_ref})" if backend == "api" else " (OpenCode plugin)"))
 
-    user_prompt = (
+    pr_header = (
         f"Repository: {repo}\n"
         f"PR #{pr_number}: {pr.get('title', '')}\n"
         f"Author: {pr.get('user', {}).get('login', '')}\n"
-        f"Base: {pr.get('base', {}).get('ref', '')}  Head: {pr.get('head', {}).get('ref', '')}\n\n"
+        f"Base: {pr.get('base', {}).get('ref', '')}  Head: {pr.get('head', {}).get('ref', '')} ({head_sha[:7]})\n\n"
         f"PR description:\n{(pr.get('body') or '(none)').strip()}\n\n"
-        f"Unified diff ({len(kept)} files):\n\n"
-        + "".join(f.text for f in kept)
     )
 
-    log(f"Calling {model} at {base_url}")
-    raw = call_model(
-        base_url, api_key, model, system, user_prompt, temperature, max_tokens,
-        timeout=timeout, extra_body=extra_body, stream=stream,
-    )
+    if backend == "opencode":
+        base_ref = pr.get("base", {}).get("ref", "main")
+        system = build_system_prompt(ponytail_mode, ponytail_ref, extra_instructions, inline_ruleset=False)
+        system += (
+            "\n\nYou are running inside a checkout of the PR head commit with read-only tools. "
+            "Use them: get the diff with `git diff origin/" + base_ref + "...HEAD`, then read the "
+            "surrounding code, callers, and existing helpers before judging a change. "
+            "Do not attempt to edit files, run tests, install anything, or access the network. "
+            "Your final message must be ONLY the JSON object described above, nothing before or after it."
+        )
+        task = (
+            pr_header
+            + f"Changed files ({len(kept)}): " + ", ".join(f.path for f in kept) + "\n\n"
+            + f"Review this pull request. Start with `git diff origin/{base_ref}...HEAD`."
+        )
+        cfg_dir = os.path.join(env("RUNNER_TEMP", "/tmp"), "ai-review-opencode")
+        cfg_path = write_opencode_config(
+            cfg_dir, model, base_url, system, temperature, max_tokens,
+            ponytail=(ponytail_mode != "off"), extra_body=extra_body or None,
+        )
+        log(f"Calling {model} via OpenCode at {base_url}")
+        raw = call_opencode(repo_dir, cfg_path, model, task, agent_timeout)
+    else:
+        system = build_system_prompt(ponytail_mode, ponytail_ref, extra_instructions)
+        user_prompt = pr_header + f"Unified diff ({len(kept)} files):\n\n" + "".join(f.text for f in kept)
+        log(f"Calling {model} at {base_url}")
+        raw = call_model(
+            base_url, api_key, model, system, user_prompt, temperature, max_tokens,
+            timeout=timeout, extra_body=extra_body, stream=stream, json_mode=json_mode,
+        )
 
     try:
         result = extract_json(raw)

--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -24,8 +24,12 @@ Optional:
   AI_TEMPERATURE        Sampling temperature (default 0.2)
   AI_MAX_TOKENS         Max completion tokens (default 8000; reasoning models
                         spend these on thinking first, so go higher if truncated)
-  AI_TIMEOUT            Seconds to wait for the model response (default 600).
-                        Reasoning models on large diffs can take several minutes.
+  AI_TIMEOUT            Socket read timeout in seconds (default 600). With streaming
+                        on, this is per-chunk, not total, so it rarely needs raising.
+  AI_STREAM             "true" (default) streams the response, which keeps the
+                        connection alive while a reasoning model thinks and avoids
+                        gateway idle timeouts. Set "false" for providers that
+                        don't support SSE.
   AI_EXTRA_BODY         JSON object merged into the chat-completions request body
                         for provider-specific options. Examples:
                           Poolside / vLLM, turn off thinking:
@@ -46,6 +50,7 @@ Optional:
 from __future__ import annotations
 
 import fnmatch
+import http.client as httpclient
 import json
 import os
 import re
@@ -357,6 +362,101 @@ def excluded(path: str, patterns: list[str]) -> bool:
 # Model
 # --------------------------------------------------------------------------- #
 
+class ProviderError(Exception):
+    def __init__(self, status: int, body: str):
+        super().__init__(f"HTTP {status}: {body[:800]}")
+        self.status, self.body = status, body
+
+
+@dataclass
+class ModelReply:
+    content: str = ""
+    reasoning: str = ""
+    finish_reason: str | None = None
+    usage: dict = field(default_factory=dict)
+
+
+RETRYABLE = (
+    urllib.error.URLError,
+    TimeoutError,
+    ConnectionError,          # includes ConnectionResetError, RemoteDisconnected
+    httpclient.HTTPException,  # IncompleteRead, BadStatusLine, ...
+)
+
+
+def _post_chat(url: str, headers: dict, payload: dict, timeout: int) -> ModelReply:
+    """One POST. Streams if the server streams; otherwise parses a normal JSON body.
+    Raises ProviderError on 4xx/5xx and RETRYABLE on transport failures."""
+    req = urllib.request.Request(url, data=json.dumps(payload).encode(), method="POST", headers=headers)
+    try:
+        resp = urllib.request.urlopen(req, timeout=timeout)
+    except urllib.error.HTTPError as e:
+        raise ProviderError(e.code, e.read().decode(errors="replace")) from None
+
+    with resp:
+        if "text/event-stream" not in (resp.headers.get("Content-Type") or ""):
+            return _parse_nonstream(json.loads(resp.read().decode()))
+
+        reply = ModelReply()
+        last_log = time.monotonic()
+        phase = ""
+        for raw in resp:
+            line = raw.decode("utf-8", errors="replace").strip()
+            if not line.startswith("data:"):
+                continue
+            data = line[5:].strip()
+            if data == "[DONE]":
+                break
+            try:
+                ev = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(ev.get("usage"), dict):
+                reply.usage = ev["usage"]
+            for ch in ev.get("choices") or []:
+                d = ch.get("delta") or {}
+                c = d.get("content")
+                if isinstance(c, list):
+                    c = "".join(p.get("text", "") for p in c if isinstance(p, dict))
+                r = d.get("reasoning_content") or d.get("reasoning")
+                if r:
+                    reply.reasoning += r
+                    if phase != "thinking":
+                        phase = "thinking"
+                        log("Model is thinking...")
+                if c:
+                    reply.content += c
+                    if phase != "answering":
+                        phase = "answering"
+                        log(f"Model is answering (after {len(reply.reasoning)} chars of reasoning)")
+                if ch.get("finish_reason"):
+                    reply.finish_reason = ch["finish_reason"]
+            now = time.monotonic()
+            if now - last_log > 30:
+                log(f"  ...{len(reply.reasoning)} reasoning chars, {len(reply.content)} content chars so far")
+                last_log = now
+        return reply
+
+
+def _parse_nonstream(data: dict) -> ModelReply:
+    try:
+        choice = data["choices"][0]
+    except (KeyError, IndexError, TypeError) as e:
+        raise RuntimeError(f"Unexpected response shape: {json.dumps(data)[:800]}") from e
+    msg = choice.get("message") or {}
+    content = msg.get("content")
+    if isinstance(content, list):
+        content = "".join(p.get("text", "") for p in content if isinstance(p, dict))
+    if not content and isinstance(choice.get("text"), str):  # legacy completions shape
+        content = choice["text"]
+    return ModelReply(
+        content=content or "",
+        reasoning=msg.get("reasoning_content") or msg.get("reasoning") or "",
+        finish_reason=choice.get("finish_reason"),
+        usage=data.get("usage") or {},
+    )
+
+
 def call_model(
     base_url: str,
     api_key: str,
@@ -367,14 +467,16 @@ def call_model(
     max_tokens: int,
     timeout: int = 600,
     extra_body: dict | None = None,
+    stream: bool = True,
 ) -> str:
     url = base_url.rstrip("/") + "/chat/completions"
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
+        "Accept": "text/event-stream, application/json",
         "User-Agent": "ai-pr-review",
     }
-    base_payload = {
+    payload: dict = {
         "model": model,
         "temperature": temperature,
         "max_tokens": max_tokens,
@@ -382,73 +484,73 @@ def call_model(
             {"role": "system", "content": system},
             {"role": "user", "content": user},
         ],
+        "response_format": {"type": "json_object"},
     }
+    if stream:
+        # Streaming keeps the connection alive while a reasoning model thinks, so
+        # gateway idle timeouts don't kill long requests.
+        payload["stream"] = True
+        payload["stream_options"] = {"include_usage": True}
     if extra_body:
-        base_payload.update(extra_body)  # provider-specific knobs, e.g. chat_template_kwargs
+        payload.update(extra_body)  # provider-specific knobs, e.g. chat_template_kwargs
 
-    # Try with JSON mode first; adapt to whichever parameters the provider rejects.
-    payload = dict(base_payload, response_format={"type": "json_object"})
-    status, text = http("POST", url, headers, payload, retries=2, timeout=timeout)
-    for attempt in range(3):
-        if status != 400:
+    reply: ModelReply | None = None
+    transport_failures = 0
+    for _ in range(8):  # bounded: at most a few param adaptations + 2 transport retries
+        try:
+            reply = _post_chat(url, headers, payload, timeout)
             break
-        err = text.lower()
-        if "response_format" in err and "response_format" in payload:
-            log("Provider rejected response_format; retrying without JSON mode")
-            payload.pop("response_format")
-        elif "max_completion_tokens" in err and "max_tokens" in payload:
-            log("Provider wants max_completion_tokens; retrying")
-            payload["max_completion_tokens"] = payload.pop("max_tokens")
-        elif "temperature" in err and "temperature" in payload:
-            log("Provider rejected temperature; retrying without it")
-            payload.pop("temperature")
-        else:
-            break
-        status, text = http("POST", url, headers, payload, retries=2, timeout=timeout)
+        except ProviderError as e:
+            err = e.body.lower()
+            if e.status == 400 and "response_format" in err and "response_format" in payload:
+                log("Provider rejected response_format; retrying without JSON mode")
+                payload.pop("response_format")
+            elif e.status == 400 and "stream_options" in err and "stream_options" in payload:
+                log("Provider rejected stream_options; retrying without it")
+                payload.pop("stream_options")
+            elif e.status == 400 and "stream" in err and payload.get("stream"):
+                log("Provider rejected streaming; retrying non-streaming")
+                payload.pop("stream", None)
+                payload.pop("stream_options", None)
+            elif e.status == 400 and "max_completion_tokens" in err and "max_tokens" in payload:
+                log("Provider wants max_completion_tokens; retrying")
+                payload["max_completion_tokens"] = payload.pop("max_tokens")
+            elif e.status == 400 and "temperature" in err and "temperature" in payload:
+                log("Provider rejected temperature; retrying without it")
+                payload.pop("temperature")
+            elif e.status in (429, 500, 502, 503, 504) and transport_failures < 2:
+                transport_failures += 1
+                log(f"HTTP {e.status} from provider (retry {transport_failures}/2): {e.body[:200]}")
+                time.sleep(5 * transport_failures)
+            else:
+                raise RuntimeError(f"Model request failed ({e.status}): {e.body[:800]}") from None
+        except RETRYABLE as e:
+            transport_failures += 1
+            if transport_failures > 2:
+                raise RuntimeError(f"Model request failed after retries: {e!r}") from None
+            log(f"Transport error (retry {transport_failures}/2): {e!r}")
+            time.sleep(5 * transport_failures)
+    if reply is None:
+        raise RuntimeError("Model request failed: too many parameter adaptations")
 
-    if status != 200:
-        raise RuntimeError(f"Model request failed ({status}): {text[:800]}")
-
-    data = json.loads(text)
-    try:
-        choice = data["choices"][0]
-    except (KeyError, IndexError, TypeError) as e:
-        raise RuntimeError(f"Unexpected response shape: {text[:800]}") from e
-
-    msg = choice.get("message") or {}
-    content = msg.get("content")
-
-    # Some providers return content as a list of {"type": "text", "text": ...} parts
-    if isinstance(content, list):
-        content = "".join(p.get("text", "") for p in content if isinstance(p, dict))
-
-    # Some put the answer in a reasoning field, or use the legacy completions shape
-    if not content:
-        for key in ("reasoning_content", "reasoning", "refusal"):
-            if isinstance(msg.get(key), str) and msg[key].strip():
-                log(f"::warning::message.content was empty; using message.{key}")
-                content = msg[key]
-                break
-    if not content and isinstance(choice.get("text"), str):
-        content = choice["text"]
-
-    finish = choice.get("finish_reason")
-    usage = data.get("usage") or {}
-    if usage:
-        log(f"Usage: {json.dumps(usage)}")
-
-    if finish == "length":
+    if reply.usage:
+        log(f"Usage: {json.dumps(reply.usage)}")
+    if reply.finish_reason == "length":
         log(
             "::warning::Response was cut off at max_tokens. Reasoning models spend tokens "
-            "thinking before answering; raise AI_MAX_TOKENS (e.g. 16000) or lower AI_MAX_DIFF_CHARS."
+            "thinking before answering; raise AI_MAX_TOKENS or lower AI_MAX_DIFF_CHARS."
         )
-    if not content or not str(content).strip():
+
+    content = reply.content
+    if not content.strip() and reply.reasoning.strip():
+        log("::warning::content was empty; falling back to reasoning text")
+        content = reply.reasoning
+    if not content.strip():
         raise RuntimeError(
-            f"Model returned no content (finish_reason={finish!r}). "
-            + ("It hit the token limit; raise AI_MAX_TOKENS. " if finish == "length" else "")
-            + f"Raw response: {text[:800]}"
+            f"Model returned no content (finish_reason={reply.finish_reason!r}). "
+            + ("It hit the token limit; raise AI_MAX_TOKENS. " if reply.finish_reason == "length" else "")
         )
-    return str(content)
+    return content
 
 
 def extract_json(text: str) -> dict:
@@ -496,6 +598,7 @@ def main() -> int:
     temperature = float(env("AI_TEMPERATURE", "0.2"))
     max_tokens = int(env("AI_MAX_TOKENS", "8000"))
     timeout = int(env("AI_TIMEOUT", "600"))
+    stream = env("AI_STREAM", "true").strip().lower() not in ("false", "0", "no", "off")
     extra_body: dict = {}
     if env("AI_EXTRA_BODY"):
         try:
@@ -559,7 +662,7 @@ def main() -> int:
     log(f"Calling {model} at {base_url}")
     raw = call_model(
         base_url, api_key, model, system, user_prompt, temperature, max_tokens,
-        timeout=timeout, extra_body=extra_body,
+        timeout=timeout, extra_body=extra_body, stream=stream,
     )
 
     try:

--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -71,12 +71,15 @@ import fnmatch
 import http.client as httpclient
 import json
 import os
+import random
 import re
 import sys
 import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 
 REVIEW_MARKER = "<!-- ai-pr-review -->"
 
@@ -245,6 +248,30 @@ def log(msg: str) -> None:
     print(msg, flush=True)
 
 
+def parse_retry_after(headers) -> float | None:
+    """Seconds to wait per a Retry-After header (delta or HTTP-date form), or None."""
+    value = headers.get("Retry-After") if headers else None
+    if not value:
+        return None
+    try:
+        seconds = float(value)
+    except ValueError:
+        try:
+            seconds = (parsedate_to_datetime(value) - datetime.now(timezone.utc)).total_seconds()
+        except (TypeError, ValueError):
+            return None
+    return min(max(seconds, 0.0), 120.0)
+
+
+def retry_delay(err: urllib.error.HTTPError | None, attempt: int) -> float:
+    """Honor a provider-specified Retry-After; otherwise exponential backoff with jitter."""
+    if err is not None:
+        specified = parse_retry_after(err.headers)
+        if specified is not None:
+            return specified
+    return 2 ** attempt + random.uniform(0, 1)
+
+
 def http(
     method: str,
     url: str,
@@ -257,6 +284,7 @@ def http(
     last_err: Exception | None = None
     for attempt in range(retries):
         req = urllib.request.Request(url, data=data, method=method, headers=headers)
+        http_err: urllib.error.HTTPError | None = None
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
                 return resp.status, resp.read().decode()
@@ -265,12 +293,15 @@ def http(
             # Don't retry client errors other than rate limits
             if e.code < 500 and e.code != 429:
                 return e.code, text
-            last_err = e
+            last_err = http_err = e
             log(f"HTTP {e.code} from {url} (attempt {attempt + 1}/{retries}): {text[:300]}")
         except (urllib.error.URLError, TimeoutError) as e:
             last_err = e
             log(f"Network error calling {url} (attempt {attempt + 1}/{retries}): {e}")
-        time.sleep(2 ** attempt)
+        if attempt + 1 < retries:
+            delay = retry_delay(http_err, attempt)
+            log(f"  waiting {delay:.1f}s before retrying")
+            time.sleep(delay)
     raise RuntimeError(f"Request to {url} failed after {retries} attempts: {last_err}")
 
 
@@ -302,16 +333,48 @@ class GitHub:
             raise RuntimeError(f"Failed to fetch diff: {status} {text[:300]}")
         return text
 
-    def create_review(self, number: int, commit_id: str, body: str, comments: list[dict]) -> bool:
+    def _already_published(self, number: int, marker: str) -> bool:
+        """True if a review or issue comment carrying this run's marker exists."""
+        for url in (
+            f"{self.base}/pulls/{number}/reviews?per_page=100",
+            f"{self.base}/issues/{number}/comments?per_page=100",
+        ):
+            try:
+                status, text = http("GET", url, self.headers, retries=2, timeout=30)
+            except RuntimeError:
+                continue
+            if status == 200 and any(marker in (item.get("body") or "") for item in json.loads(text)):
+                return True
+        return False
+
+    def _post_write(self, url: str, number: int, payload: dict, marker: str) -> tuple[int, str]:
+        """POST without blind retries: GitHub can accept a write while the client
+        sees a timeout or 5xx, so a naive retry can publish a duplicate. On an
+        ambiguous failure, look for this run's marker before trying again."""
+        last_err: Exception | None = None
+        for attempt in range(3):
+            try:
+                return http("POST", url, self.headers, payload, retries=1)
+            except RuntimeError as e:
+                last_err = e
+                if marker and self._already_published(number, marker):
+                    log("The write landed despite the transport error; not retrying")
+                    return 201, ""
+                if attempt < 2:
+                    log(f"Write failed and nothing was published; retrying: {e}")
+                    time.sleep(2 * (attempt + 1) + random.uniform(0, 1))
+        raise RuntimeError(f"GitHub write to {url} failed: {last_err}")
+
+    def create_review(self, number: int, commit_id: str, body: str, comments: list[dict], marker: str = "") -> bool:
         payload = {"commit_id": commit_id, "body": body, "event": "COMMENT", "comments": comments}
-        status, text = http("POST", f"{self.base}/pulls/{number}/reviews", self.headers, payload)
+        status, text = self._post_write(f"{self.base}/pulls/{number}/reviews", number, payload, marker)
         if status in (200, 201):
             return True
         log(f"::warning::Review creation failed ({status}): {text[:500]}")
         return False
 
-    def create_issue_comment(self, number: int, body: str) -> None:
-        status, text = http("POST", f"{self.base}/issues/{number}/comments", self.headers, {"body": body})
+    def create_issue_comment(self, number: int, body: str, marker: str = "") -> None:
+        status, text = self._post_write(f"{self.base}/issues/{number}/comments", number, {"body": body}, marker)
         if status not in (200, 201):
             raise RuntimeError(f"Failed to post comment: {status} {text[:300]}")
 
@@ -329,6 +392,52 @@ class FileDiff:
 
 HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
 
+# A git C-quoted string: `"..."` with backslash escapes inside
+_QUOTED = r'"(?:[^"\\]|\\.)*"'
+_C_ESCAPES = {"n": 10, "t": 9, "r": 13, "a": 7, "b": 8, "f": 12, "v": 11, '"': 34, "\\": 92}
+
+
+def _unquote_c(s: str) -> str:
+    """Decode the inside of a git C-quoted path: octal byte escapes plus \\n, \\t, \\", \\\\ etc."""
+    out = bytearray()
+    i = 0
+    while i < len(s):
+        ch = s[i]
+        if ch == "\\" and i + 1 < len(s):
+            nxt = s[i + 1]
+            if nxt in "01234567":
+                j = i + 1
+                while j < len(s) and j < i + 4 and s[j] in "01234567":
+                    j += 1
+                out.append(int(s[i + 1:j], 8))
+                i = j
+                continue
+            if nxt in _C_ESCAPES:
+                out.append(_C_ESCAPES[nxt])
+                i += 2
+                continue
+        out.extend(ch.encode("utf-8"))
+        i += 1
+    return out.decode("utf-8", errors="replace")
+
+
+def _diff_header_path(raw: str) -> str:
+    """Post-image repository path from a `diff --git` header. Git C-quotes paths
+    containing quotes, backslashes, control bytes, or (by default) non-ASCII, so
+    the quoted form must be decoded back to the real path or exclude patterns
+    and inline-comment anchoring miss the file."""
+    rest = raw[len("diff --git "):]
+    m = re.match(r'^(?:%s|a/.*?) "b/((?:[^"\\]|\\.)*)"$' % _QUOTED, rest)
+    if m:
+        return _unquote_c(m.group(1))
+    m = re.match(r'^%s b/(.+)$' % _QUOTED, rest)
+    if m:
+        return m.group(1)
+    m = re.match(r"^a/(.+?) b/(.+)$", rest)
+    if m:
+        return m.group(2)
+    return rest.split(" b/")[-1]
+
 
 def parse_diff(diff: str) -> list[FileDiff]:
     """Split a unified diff into per-file chunks and record which new-file
@@ -342,10 +451,7 @@ def parse_diff(diff: str) -> list[FileDiff]:
         if raw.startswith("diff --git "):
             if current:
                 files.append(current)
-            # "diff --git a/path b/path" -> take the b/ path
-            m = re.match(r'^diff --git a/(.+?) b/(.+)$', raw)
-            path = m.group(2) if m else raw.split(" b/")[-1]
-            current = FileDiff(path=path, text=raw + "\n")
+            current = FileDiff(path=_diff_header_path(raw), text=raw + "\n")
             in_hunk = False
             continue
 
@@ -388,9 +494,9 @@ def excluded(path: str, patterns: list[str]) -> bool:
 # --------------------------------------------------------------------------- #
 
 class ProviderError(Exception):
-    def __init__(self, status: int, body: str):
+    def __init__(self, status: int, body: str, retry_after: float | None = None):
         super().__init__(f"HTTP {status}: {body[:800]}")
-        self.status, self.body = status, body
+        self.status, self.body, self.retry_after = status, body, retry_after
 
 
 @dataclass
@@ -416,7 +522,7 @@ def _post_chat(url: str, headers: dict, payload: dict, timeout: int) -> ModelRep
     try:
         resp = urllib.request.urlopen(req, timeout=timeout)
     except urllib.error.HTTPError as e:
-        raise ProviderError(e.code, e.read().decode(errors="replace")) from None
+        raise ProviderError(e.code, e.read().decode(errors="replace"), parse_retry_after(e.headers)) from None
 
     with resp:
         if "text/event-stream" not in (resp.headers.get("Content-Type") or ""):
@@ -523,7 +629,7 @@ def call_model(
 
     def request(payload: dict) -> ModelReply:
         transport_failures = 0
-        for _ in range(8):  # bounded: a few param adaptations + 2 transport retries
+        for _ in range(9):  # bounded: a few param adaptations + 3 transport retries
             try:
                 return _post_chat(url, headers, payload, timeout)
             except ProviderError as e:
@@ -544,18 +650,22 @@ def call_model(
                 elif e.status == 400 and "temperature" in err and "temperature" in payload:
                     log("Provider rejected temperature; retrying without it")
                     payload.pop("temperature")
-                elif e.status in (429, 500, 502, 503, 504) and transport_failures < 2:
+                elif e.status in (429, 500, 502, 503, 504) and transport_failures < 3:
                     transport_failures += 1
-                    log(f"HTTP {e.status} from provider (retry {transport_failures}/2): {e.body[:200]}")
-                    time.sleep(5 * transport_failures)
+                    # Honor the provider's Retry-After (OpenRouter sends one on 429);
+                    # fall back to backoff with jitter so retries don't align with the window.
+                    delay = e.retry_after if e.retry_after is not None \
+                        else 5 * transport_failures + random.uniform(0, 2)
+                    log(f"HTTP {e.status} from provider (retry {transport_failures}/3, waiting {delay:.1f}s): {e.body[:200]}")
+                    time.sleep(delay)
                 else:
                     raise RuntimeError(f"Model request failed ({e.status}): {e.body[:800]}") from None
             except RETRYABLE as e:
                 transport_failures += 1
-                if transport_failures > 2:
+                if transport_failures > 3:
                     raise RuntimeError(f"Model request failed after retries: {e!r}") from None
-                log(f"Transport error (retry {transport_failures}/2): {e!r}")
-                time.sleep(5 * transport_failures)
+                log(f"Transport error (retry {transport_failures}/3): {e!r}")
+                time.sleep(5 * transport_failures + random.uniform(0, 2))
         raise RuntimeError("Model request failed: too many parameter adaptations")
 
     def report(reply: ModelReply) -> None:
@@ -627,6 +737,14 @@ READ_ONLY_BASH = {
     "wc *": "allow",
     "tree*": "allow",
     "pwd*": "allow",
+    # Last-match-wins: these override the allowances above and keep every
+    # allowed reader inside the checkout. Absolute paths and parent-dir
+    # escapes are denied, which also blocks /proc/self/environ (where
+    # AI_API_KEY would be readable) and anything else on the runner.
+    "* /*": "deny",
+    "* ../*": "deny",
+    "*/../*": "deny",
+    "*/proc/*": "deny",
 }
 
 
@@ -676,7 +794,15 @@ def write_opencode_config(
             "websearch": "deny",
             "external_directory": "deny",
             "doom_loop": "deny",
-            "read": {"*": "allow", "*.env": "deny", "*.env.*": "deny", "*.pem": "deny", "*.key": "deny"},
+            "read": {
+                "*": "allow",
+                "*.env": "deny",
+                "*.env.*": "deny",
+                "*.pem": "deny",
+                "*.key": "deny",
+                "/proc/**": "deny",
+                "**/.git/config": "deny",
+            },
         },
         "agent": {
             "reviewer": {
@@ -928,8 +1054,19 @@ def main() -> int:
 
     gh = GitHub(gh_token, repo)
 
+    def head_moved(pr_data: dict) -> bool:
+        """A push after this run started makes the diff/commit_id pair unreliable
+        and the review stale; the run triggered by the new head covers it."""
+        live = str(pr_data.get("head", {}).get("sha", ""))
+        if live and live != head_sha:
+            log(f"PR head moved from {head_sha[:7]} to {live[:7]}; skipping so the newer run reviews it.")
+            return True
+        return False
+
     log(f"Fetching PR #{pr_number} from {repo}")
     pr = gh.get_pr(pr_number)
+    if head_moved(pr):
+        return 0
     diff = gh.get_diff(pr_number)
     files = parse_diff(diff)
 
@@ -1074,8 +1211,11 @@ def main() -> int:
                                                  else f"`net: {net_lines:+d} lines possible`")
     else:
         heading = f"## {VERDICT_ICON[verdict]} AI Review — {verdict.replace('_', ' ').title()}"
+    # Marker is unique per pass and head commit so an ambiguous GitHub write
+    # failure can check whether this exact review already landed.
+    marker = REVIEW_MARKER.replace("-->", f" {ponytail_mode} {head_sha[:12]} -->")
     parts = [
-        REVIEW_MARKER.replace("-->", f" {ponytail_mode} -->"),
+        marker,
         heading,
         "",
         summary,
@@ -1107,8 +1247,12 @@ def main() -> int:
             log(f"{c['path']}:{c['line']}  {c['body'][:200]}")
         return 0
 
+    # Don't publish a review of a commit that is no longer the head.
+    if head_moved(gh.get_pr(pr_number)):
+        return 0
+
     # Post: try full review with inline comments, then without, then as a plain comment
-    if gh.create_review(pr_number, head_sha, body, inline):
+    if gh.create_review(pr_number, head_sha, body, inline, marker=marker):
         log(f"Posted review with {len(inline)} inline comment(s)")
         return 0
     if inline:
@@ -1116,9 +1260,11 @@ def main() -> int:
         fallback_body = body + "\n\n### Inline comments (could not be attached)\n" + "\n".join(
             f"- `{c['path']}:{c['line']}` — {c['body']}" for c in inline
         )
-        if gh.create_review(pr_number, head_sha, fallback_body, []):
+        if gh.create_review(pr_number, head_sha, fallback_body, [], marker=marker):
             return 0
-    gh.create_issue_comment(pr_number, body)
+    if head_moved(gh.get_pr(pr_number)):
+        return 0
+    gh.create_issue_comment(pr_number, body, marker=marker)
     log("Posted review as an issue comment")
     return 0
 

--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -22,7 +22,17 @@ Required:
 Optional:
   AI_MAX_DIFF_CHARS     Cap on diff size sent to the model (default 120000)
   AI_TEMPERATURE        Sampling temperature (default 0.2)
-  AI_MAX_TOKENS         Max completion tokens (default 4000)
+  AI_MAX_TOKENS         Max completion tokens (default 8000; reasoning models
+                        spend these on thinking first, so go higher if truncated)
+  AI_TIMEOUT            Seconds to wait for the model response (default 600).
+                        Reasoning models on large diffs can take several minutes.
+  AI_EXTRA_BODY         JSON object merged into the chat-completions request body
+                        for provider-specific options. Examples:
+                          Poolside / vLLM, turn off thinking:
+                            {"chat_template_kwargs": {"enable_thinking": false}}
+                          OpenRouter, cap reasoning effort:
+                            {"reasoning": {"effort": "low"}}
+                          Ollama:  {"think": false}
   AI_EXCLUDE_PATTERNS   Comma-separated fnmatch globs to skip, e.g.
                         "*.lock,package-lock.json,dist/*,*.min.js"
   AI_EXTRA_INSTRUCTIONS Free text appended to the system prompt
@@ -355,6 +365,8 @@ def call_model(
     user: str,
     temperature: float,
     max_tokens: int,
+    timeout: int = 600,
+    extra_body: dict | None = None,
 ) -> str:
     url = base_url.rstrip("/") + "/chat/completions"
     headers = {
@@ -371,35 +383,95 @@ def call_model(
             {"role": "user", "content": user},
         ],
     }
+    if extra_body:
+        base_payload.update(extra_body)  # provider-specific knobs, e.g. chat_template_kwargs
 
-    # First try with JSON mode; many providers support it, some 400 on it.
+    # Try with JSON mode first; adapt to whichever parameters the provider rejects.
     payload = dict(base_payload, response_format={"type": "json_object"})
-    status, text = http("POST", url, headers, payload)
-    if status == 400 and "response_format" in text:
-        log("Provider rejected response_format; retrying without JSON mode")
-        status, text = http("POST", url, headers, base_payload)
+    status, text = http("POST", url, headers, payload, retries=2, timeout=timeout)
+    for attempt in range(3):
+        if status != 400:
+            break
+        err = text.lower()
+        if "response_format" in err and "response_format" in payload:
+            log("Provider rejected response_format; retrying without JSON mode")
+            payload.pop("response_format")
+        elif "max_completion_tokens" in err and "max_tokens" in payload:
+            log("Provider wants max_completion_tokens; retrying")
+            payload["max_completion_tokens"] = payload.pop("max_tokens")
+        elif "temperature" in err and "temperature" in payload:
+            log("Provider rejected temperature; retrying without it")
+            payload.pop("temperature")
+        else:
+            break
+        status, text = http("POST", url, headers, payload, retries=2, timeout=timeout)
 
     if status != 200:
         raise RuntimeError(f"Model request failed ({status}): {text[:800]}")
 
     data = json.loads(text)
     try:
-        return data["choices"][0]["message"]["content"]
+        choice = data["choices"][0]
     except (KeyError, IndexError, TypeError) as e:
         raise RuntimeError(f"Unexpected response shape: {text[:800]}") from e
 
+    msg = choice.get("message") or {}
+    content = msg.get("content")
+
+    # Some providers return content as a list of {"type": "text", "text": ...} parts
+    if isinstance(content, list):
+        content = "".join(p.get("text", "") for p in content if isinstance(p, dict))
+
+    # Some put the answer in a reasoning field, or use the legacy completions shape
+    if not content:
+        for key in ("reasoning_content", "reasoning", "refusal"):
+            if isinstance(msg.get(key), str) and msg[key].strip():
+                log(f"::warning::message.content was empty; using message.{key}")
+                content = msg[key]
+                break
+    if not content and isinstance(choice.get("text"), str):
+        content = choice["text"]
+
+    finish = choice.get("finish_reason")
+    usage = data.get("usage") or {}
+    if usage:
+        log(f"Usage: {json.dumps(usage)}")
+
+    if finish == "length":
+        log(
+            "::warning::Response was cut off at max_tokens. Reasoning models spend tokens "
+            "thinking before answering; raise AI_MAX_TOKENS (e.g. 16000) or lower AI_MAX_DIFF_CHARS."
+        )
+    if not content or not str(content).strip():
+        raise RuntimeError(
+            f"Model returned no content (finish_reason={finish!r}). "
+            + ("It hit the token limit; raise AI_MAX_TOKENS. " if finish == "length" else "")
+            + f"Raw response: {text[:800]}"
+        )
+    return str(content)
+
 
 def extract_json(text: str) -> dict:
-    """Tolerate code fences, leading prose, and <think> blocks."""
-    text = re.sub(r"<think>.*?</think>", "", text, flags=re.S).strip()
+    """Tolerate code fences, leading/trailing prose, <think> blocks, and an
+    unterminated reasoning block. Scans for the first balanced {...} that parses."""
+    text = re.sub(r"<think>.*?</think>", "", text, flags=re.S)
+    text = re.sub(r"<think>.*\Z", "", text, flags=re.S).strip()  # unterminated
     fence = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, flags=re.S)
     if fence:
-        text = fence.group(1)
-    else:
-        start, end = text.find("{"), text.rfind("}")
-        if start != -1 and end != -1:
-            text = text[start : end + 1]
-    return json.loads(text)
+        try:
+            return json.loads(fence.group(1))
+        except json.JSONDecodeError:
+            pass
+    # Walk candidate start braces; find a balanced object that parses
+    decoder = json.JSONDecoder()
+    for m in re.finditer(r"\{", text):
+        try:
+            obj, _ = decoder.raw_decode(text, m.start())
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and ("summary" in obj or "comments" in obj):
+            return obj
+    raise json.JSONDecodeError("no review object found", text, 0)
 
 
 # --------------------------------------------------------------------------- #
@@ -422,7 +494,17 @@ def main() -> int:
 
     max_chars = int(env("AI_MAX_DIFF_CHARS", "120000"))
     temperature = float(env("AI_TEMPERATURE", "0.2"))
-    max_tokens = int(env("AI_MAX_TOKENS", "4000"))
+    max_tokens = int(env("AI_MAX_TOKENS", "8000"))
+    timeout = int(env("AI_TIMEOUT", "600"))
+    extra_body: dict = {}
+    if env("AI_EXTRA_BODY"):
+        try:
+            extra_body = json.loads(env("AI_EXTRA_BODY"))
+            if not isinstance(extra_body, dict):
+                raise ValueError("must be a JSON object")
+        except (json.JSONDecodeError, ValueError) as e:
+            log(f"::warning::AI_EXTRA_BODY is not a JSON object ({e}); ignoring")
+            extra_body = {}
     extra_instructions = env("AI_EXTRA_INSTRUCTIONS")
     ponytail_mode = env("AI_PONYTAIL", "off").strip().lower()
     if ponytail_mode in ("true", "1", "yes", "hybrid"):
@@ -475,13 +557,28 @@ def main() -> int:
     )
 
     log(f"Calling {model} at {base_url}")
-    raw = call_model(base_url, api_key, model, system, user_prompt, temperature, max_tokens)
+    raw = call_model(
+        base_url, api_key, model, system, user_prompt, temperature, max_tokens,
+        timeout=timeout, extra_body=extra_body,
+    )
 
     try:
         result = extract_json(raw)
     except json.JSONDecodeError:
-        log("::warning::Model did not return valid JSON; posting raw output")
-        result = {"summary": raw, "verdict": "COMMENT", "comments": []}
+        log("::warning::Model did not return valid JSON. First 1500 chars of output:")
+        log(raw[:1500])
+        result = {
+            "summary": (
+                "_The model returned output that could not be parsed as a review. "
+                "Check the workflow log for the raw response. If the model is a reasoning "
+                "model, try raising `AI_MAX_TOKENS` or disabling thinking via `AI_EXTRA_BODY`._\n\n"
+                "<details><summary>Raw output (truncated)</summary>\n\n```\n"
+                + raw[:3000].replace("```", "` ` `")
+                + "\n```\n</details>"
+            ),
+            "verdict": "COMMENT",
+            "comments": [],
+        }
 
     summary = str(result.get("summary", "")).strip() or "_No summary provided._"
     verdict = str(result.get("verdict", "COMMENT")).upper()

--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -1,0 +1,570 @@
+#!/usr/bin/env python3
+"""
+AI pull-request reviewer for GitHub Actions.
+
+Works with any OpenAI-compatible chat-completions endpoint
+(OpenAI, Azure OpenAI, Groq, Together, OpenRouter, Mistral, DeepSeek,
+vLLM, LM Studio, Ollama, llama.cpp server, etc.).
+
+Only uses the Python standard library so no `pip install` step is needed.
+
+Environment variables
+---------------------
+Required:
+  AI_API_KEY            Bearer token for the provider
+  AI_BASE_URL           Base URL, e.g. https://api.openai.com/v1
+  AI_MODEL              Model name, e.g. gpt-4o-mini
+  GITHUB_TOKEN          Provided automatically by Actions
+  GITHUB_REPOSITORY     owner/repo (automatic)
+  PR_NUMBER             Pull request number
+  PR_HEAD_SHA           Head commit SHA (reviews must be tied to a commit)
+
+Optional:
+  AI_MAX_DIFF_CHARS     Cap on diff size sent to the model (default 120000)
+  AI_TEMPERATURE        Sampling temperature (default 0.2)
+  AI_MAX_TOKENS         Max completion tokens (default 4000)
+  AI_EXCLUDE_PATTERNS   Comma-separated fnmatch globs to skip, e.g.
+                        "*.lock,package-lock.json,dist/*,*.min.js"
+  AI_EXTRA_INSTRUCTIONS Free text appended to the system prompt
+                        (e.g. team conventions to enforce)
+  AI_PONYTAIL           "off" (default), "on" = correctness review + Ponytail
+                        over-engineering pass, "only" = Ponytail pass alone.
+                        Loads the ruleset from github.com/DietrichGebert/ponytail
+  AI_PONYTAIL_REF       Git ref of the Ponytail repo to load (default: pinned tag)
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+
+REVIEW_MARKER = "<!-- ai-pr-review -->"
+
+DEFAULT_EXCLUDES = [
+    "*.lock",
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "poetry.lock",
+    "Cargo.lock",
+    "go.sum",
+    "*.min.js",
+    "*.min.css",
+    "*.map",
+    "*.svg",
+    "*.png",
+    "*.jpg",
+    "*.jpeg",
+    "*.gif",
+    "*.ico",
+    "*.pdf",
+    "*.snap",
+]
+
+# --------------------------------------------------------------------------- #
+# Prompts
+# --------------------------------------------------------------------------- #
+
+CORRECTNESS_PROMPT = """You are a senior software engineer performing a code review on a GitHub pull request.
+
+Your job is to find real problems, not to nitpick style. Prioritize, in order:
+1. Bugs, logic errors, off-by-one errors, unhandled edge cases
+2. Security issues (injection, auth/authz gaps, secrets, unsafe deserialization, SSRF, etc.)
+3. Data loss or corruption risks, race conditions, resource leaks
+4. Performance problems that matter (N+1 queries, unbounded loops, blocking I/O in hot paths)
+5. Maintainability concerns that will realistically cause pain later
+6. Missing or inadequate tests for risky changes
+"""
+
+COMMON_RULES = """
+Rules:
+- Only comment on lines that appear in the diff. Use the exact file path and NEW-file line number shown.
+- Be specific and actionable. Say what is wrong and how to fix it. Include a short code suggestion when it helps.
+- Do not praise, do not restate what the code does, do not comment on formatting a linter would catch.
+- If the change looks good, say so briefly and return an empty comments list.
+- Keep the summary under 200 words.
+"""
+
+OUTPUT_SCHEMA = """
+You MUST respond with a single JSON object and nothing else, in this exact shape:
+{
+  "summary": "Markdown summary of the review. High-level assessment plus any cross-cutting concerns.",
+  "verdict": "APPROVE" | "COMMENT" | "REQUEST_CHANGES",
+  "comments": [
+    {"path": "src/example.py", "line": 42, "severity": "high" | "medium" | "low", "body": "Markdown comment text"}
+  ]
+}
+"""
+
+# Ponytail (https://github.com/DietrichGebert/ponytail, MIT) is a ruleset, not a
+# model. We pull its core rules + the `ponytail-review` skill and inject them
+# into the system prompt. Pinned to a tag so upstream edits can't silently
+# change review behaviour; override with AI_PONYTAIL_REF.
+PONYTAIL_REPO = "DietrichGebert/ponytail"
+PONYTAIL_DEFAULT_REF = "v4.9.0"
+PONYTAIL_FILES = ["AGENTS.md", "skills/ponytail-review/SKILL.md"]
+
+PONYTAIL_SCHEMA_ADDENDUM = """
+Ponytail additions to the JSON shape:
+- Over-engineering findings go in "comments" too, but with an extra "tag" field:
+    {"path": "src/x.py", "line": 12, "tag": "delete" | "stdlib" | "native" | "yagni" | "shrink",
+     "severity": "low", "body": "<what to cut>. <what replaces it>."}
+  Keep the body to one line, in the ponytail-review style. No "consider", no hedging.
+- Add a top-level integer "ponytail_net_lines": the total lines that could be removed (negative number, e.g. -37).
+  Use 0 if the diff is lean already.
+"""
+
+PONYTAIL_HYBRID_NOTE = """
+You are running TWO review passes on the same diff and must report both:
+(a) the correctness/security review described above, and
+(b) the Ponytail over-engineering review described below.
+Correctness findings use "severity" and no "tag". Ponytail findings use "tag".
+Never flag validation at trust boundaries, security checks, error handling that prevents
+data loss, accessibility, or a single smoke test as bloat. If a line has both a bug and
+bloat, report the bug; the rewrite will remove the bloat anyway.
+"""
+
+PONYTAIL_ONLY_NOTE = """
+You are performing ONLY the Ponytail over-engineering review described below. Correctness,
+security, and performance are explicitly out of scope; do not comment on them. Every
+comment must carry a "tag". Your verdict is "COMMENT" unless the diff is lean, in which
+case it is "APPROVE" with summary "Lean already. Ship."
+"""
+
+
+def fetch_ponytail(ref: str) -> str:
+    """Download the Ponytail ruleset and review skill (raw, MIT-licensed)."""
+    parts = []
+    for path in PONYTAIL_FILES:
+        url = f"https://raw.githubusercontent.com/{PONYTAIL_REPO}/{ref}/{path}"
+        status, text = http("GET", url, {"User-Agent": "ai-pr-review"}, retries=2, timeout=30)
+        if status != 200:
+            raise RuntimeError(f"Could not fetch {url} ({status})")
+        # Strip YAML front-matter from the skill file; the model doesn't need it.
+        text = re.sub(r"\A---\n.*?\n---\n", "", text, flags=re.S)
+        parts.append(f"### {path}\n\n{text.strip()}")
+    return "\n\n".join(parts)
+
+
+def build_system_prompt(ponytail_mode: str, ponytail_ref: str, extra: str) -> str:
+    """ponytail_mode: 'off' (default), 'on' (hybrid), or 'only'."""
+    if ponytail_mode == "off":
+        prompt = CORRECTNESS_PROMPT + COMMON_RULES + OUTPUT_SCHEMA
+    else:
+        try:
+            ruleset = fetch_ponytail(ponytail_ref)
+        except Exception as e:
+            log(f"::warning::Ponytail requested but could not be loaded ({e}); falling back to standard review")
+            ponytail_mode = "off"
+            ruleset = ""
+        if ponytail_mode == "only":
+            prompt = (
+                "You are a senior software engineer reviewing a GitHub pull request.\n"
+                + PONYTAIL_ONLY_NOTE
+                + COMMON_RULES
+                + "\n## Ponytail ruleset\n\n" + ruleset + "\n"
+                + OUTPUT_SCHEMA + PONYTAIL_SCHEMA_ADDENDUM
+            )
+        elif ponytail_mode == "on":
+            prompt = (
+                CORRECTNESS_PROMPT
+                + PONYTAIL_HYBRID_NOTE
+                + COMMON_RULES
+                + "\n## Ponytail ruleset\n\n" + ruleset + "\n"
+                + OUTPUT_SCHEMA + PONYTAIL_SCHEMA_ADDENDUM
+            )
+        else:
+            prompt = CORRECTNESS_PROMPT + COMMON_RULES + OUTPUT_SCHEMA
+    if extra:
+        prompt += "\n\nAdditional project-specific instructions:\n" + extra
+    return prompt
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+def env(name: str, default: str | None = None, required: bool = False) -> str:
+    value = os.environ.get(name, "")
+    if value.strip() == "":
+        if required:
+            print(f"::error::Missing required environment variable {name}", file=sys.stderr)
+            sys.exit(1)
+        return default or ""
+    return value
+
+
+def log(msg: str) -> None:
+    print(msg, flush=True)
+
+
+def http(
+    method: str,
+    url: str,
+    headers: dict[str, str],
+    body: dict | None = None,
+    retries: int = 3,
+    timeout: int = 180,
+) -> tuple[int, str]:
+    data = json.dumps(body).encode() if body is not None else None
+    last_err: Exception | None = None
+    for attempt in range(retries):
+        req = urllib.request.Request(url, data=data, method=method, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return resp.status, resp.read().decode()
+        except urllib.error.HTTPError as e:
+            text = e.read().decode(errors="replace")
+            # Don't retry client errors other than rate limits
+            if e.code < 500 and e.code != 429:
+                return e.code, text
+            last_err = e
+            log(f"HTTP {e.code} from {url} (attempt {attempt + 1}/{retries}): {text[:300]}")
+        except (urllib.error.URLError, TimeoutError) as e:
+            last_err = e
+            log(f"Network error calling {url} (attempt {attempt + 1}/{retries}): {e}")
+        time.sleep(2 ** attempt)
+    raise RuntimeError(f"Request to {url} failed after {retries} attempts: {last_err}")
+
+
+# --------------------------------------------------------------------------- #
+# GitHub
+# --------------------------------------------------------------------------- #
+
+class GitHub:
+    def __init__(self, token: str, repo: str):
+        self.repo = repo
+        self.base = f"https://api.github.com/repos/{repo}"
+        self.headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "ai-pr-review",
+        }
+
+    def get_pr(self, number: int) -> dict:
+        status, text = http("GET", f"{self.base}/pulls/{number}", self.headers)
+        if status != 200:
+            raise RuntimeError(f"Failed to fetch PR: {status} {text[:300]}")
+        return json.loads(text)
+
+    def get_diff(self, number: int) -> str:
+        headers = dict(self.headers, Accept="application/vnd.github.v3.diff")
+        status, text = http("GET", f"{self.base}/pulls/{number}", headers)
+        if status != 200:
+            raise RuntimeError(f"Failed to fetch diff: {status} {text[:300]}")
+        return text
+
+    def create_review(self, number: int, commit_id: str, body: str, comments: list[dict]) -> bool:
+        payload = {"commit_id": commit_id, "body": body, "event": "COMMENT", "comments": comments}
+        status, text = http("POST", f"{self.base}/pulls/{number}/reviews", self.headers, payload)
+        if status in (200, 201):
+            return True
+        log(f"::warning::Review creation failed ({status}): {text[:500]}")
+        return False
+
+    def create_issue_comment(self, number: int, body: str) -> None:
+        status, text = http("POST", f"{self.base}/issues/{number}/comments", self.headers, {"body": body})
+        if status not in (200, 201):
+            raise RuntimeError(f"Failed to post comment: {status} {text[:300]}")
+
+
+# --------------------------------------------------------------------------- #
+# Diff parsing
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class FileDiff:
+    path: str
+    text: str
+    commentable_lines: set[int] = field(default_factory=set)  # NEW-file line numbers (RIGHT side)
+
+
+HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+
+
+def parse_diff(diff: str) -> list[FileDiff]:
+    """Split a unified diff into per-file chunks and record which new-file
+    line numbers are valid targets for inline review comments."""
+    files: list[FileDiff] = []
+    current: FileDiff | None = None
+    new_line = 0
+    in_hunk = False
+
+    for raw in diff.splitlines():
+        if raw.startswith("diff --git "):
+            if current:
+                files.append(current)
+            # "diff --git a/path b/path" -> take the b/ path
+            m = re.match(r'^diff --git a/(.+?) b/(.+)$', raw)
+            path = m.group(2) if m else raw.split(" b/")[-1]
+            current = FileDiff(path=path, text=raw + "\n")
+            in_hunk = False
+            continue
+
+        if current is None:
+            continue
+
+        current.text += raw + "\n"
+
+        hm = HUNK_RE.match(raw)
+        if hm:
+            new_line = int(hm.group(1))
+            in_hunk = True
+            continue
+
+        if not in_hunk:
+            continue
+
+        if raw.startswith("+"):
+            current.commentable_lines.add(new_line)
+            new_line += 1
+        elif raw.startswith("-"):
+            pass  # old-file line only; not a RIGHT-side target
+        elif raw.startswith("\\"):
+            pass  # "\ No newline at end of file"
+        else:  # context line
+            current.commentable_lines.add(new_line)
+            new_line += 1
+
+    if current:
+        files.append(current)
+    return files
+
+
+def excluded(path: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(path, p) or fnmatch.fnmatch(os.path.basename(path), p) for p in patterns)
+
+
+# --------------------------------------------------------------------------- #
+# Model
+# --------------------------------------------------------------------------- #
+
+def call_model(
+    base_url: str,
+    api_key: str,
+    model: str,
+    system: str,
+    user: str,
+    temperature: float,
+    max_tokens: int,
+) -> str:
+    url = base_url.rstrip("/") + "/chat/completions"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "User-Agent": "ai-pr-review",
+    }
+    base_payload = {
+        "model": model,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+    }
+
+    # First try with JSON mode; many providers support it, some 400 on it.
+    payload = dict(base_payload, response_format={"type": "json_object"})
+    status, text = http("POST", url, headers, payload)
+    if status == 400 and "response_format" in text:
+        log("Provider rejected response_format; retrying without JSON mode")
+        status, text = http("POST", url, headers, base_payload)
+
+    if status != 200:
+        raise RuntimeError(f"Model request failed ({status}): {text[:800]}")
+
+    data = json.loads(text)
+    try:
+        return data["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError) as e:
+        raise RuntimeError(f"Unexpected response shape: {text[:800]}") from e
+
+
+def extract_json(text: str) -> dict:
+    """Tolerate code fences, leading prose, and <think> blocks."""
+    text = re.sub(r"<think>.*?</think>", "", text, flags=re.S).strip()
+    fence = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, flags=re.S)
+    if fence:
+        text = fence.group(1)
+    else:
+        start, end = text.find("{"), text.rfind("}")
+        if start != -1 and end != -1:
+            text = text[start : end + 1]
+    return json.loads(text)
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+
+SEVERITY_ICON = {"high": "🔴", "medium": "🟠", "low": "🟡"}
+PONYTAIL_TAGS = {"delete", "stdlib", "native", "yagni", "shrink"}
+VERDICT_ICON = {"APPROVE": "✅", "COMMENT": "💬", "REQUEST_CHANGES": "🛑"}
+
+
+def main() -> int:
+    api_key = env("AI_API_KEY", required=True)
+    base_url = env("AI_BASE_URL", required=True)
+    model = env("AI_MODEL", required=True)
+    gh_token = env("GITHUB_TOKEN", required=True)
+    repo = env("GITHUB_REPOSITORY", required=True)
+    pr_number = int(env("PR_NUMBER", required=True))
+    head_sha = env("PR_HEAD_SHA", required=True)
+
+    max_chars = int(env("AI_MAX_DIFF_CHARS", "120000"))
+    temperature = float(env("AI_TEMPERATURE", "0.2"))
+    max_tokens = int(env("AI_MAX_TOKENS", "4000"))
+    extra_instructions = env("AI_EXTRA_INSTRUCTIONS")
+    ponytail_mode = env("AI_PONYTAIL", "off").strip().lower()
+    if ponytail_mode in ("true", "1", "yes", "hybrid"):
+        ponytail_mode = "on"
+    if ponytail_mode not in ("off", "on", "only"):
+        log(f"::warning::Unknown AI_PONYTAIL value {ponytail_mode!r}; using 'off'")
+        ponytail_mode = "off"
+    ponytail_ref = env("AI_PONYTAIL_REF", PONYTAIL_DEFAULT_REF)
+    excludes = DEFAULT_EXCLUDES + [
+        p.strip() for p in env("AI_EXCLUDE_PATTERNS").split(",") if p.strip()
+    ]
+
+    gh = GitHub(gh_token, repo)
+
+    log(f"Fetching PR #{pr_number} from {repo}")
+    pr = gh.get_pr(pr_number)
+    diff = gh.get_diff(pr_number)
+    files = parse_diff(diff)
+
+    kept, skipped_excluded, skipped_size = [], [], []
+    budget = max_chars
+    for f in files:
+        if excluded(f.path, excludes):
+            skipped_excluded.append(f.path)
+            continue
+        if len(f.text) > budget:
+            skipped_size.append(f.path)
+            continue
+        kept.append(f)
+        budget -= len(f.text)
+
+    if not kept:
+        log("No reviewable files after filtering; nothing to do.")
+        return 0
+
+    log(f"Reviewing {len(kept)} file(s); excluded {len(skipped_excluded)}, over budget {len(skipped_size)}")
+
+    if ponytail_mode != "off":
+        log(f"Ponytail mode: {ponytail_mode} (ref {ponytail_ref})")
+    system = build_system_prompt(ponytail_mode, ponytail_ref, extra_instructions)
+
+    user_prompt = (
+        f"Repository: {repo}\n"
+        f"PR #{pr_number}: {pr.get('title', '')}\n"
+        f"Author: {pr.get('user', {}).get('login', '')}\n"
+        f"Base: {pr.get('base', {}).get('ref', '')}  Head: {pr.get('head', {}).get('ref', '')}\n\n"
+        f"PR description:\n{(pr.get('body') or '(none)').strip()}\n\n"
+        f"Unified diff ({len(kept)} files):\n\n"
+        + "".join(f.text for f in kept)
+    )
+
+    log(f"Calling {model} at {base_url}")
+    raw = call_model(base_url, api_key, model, system, user_prompt, temperature, max_tokens)
+
+    try:
+        result = extract_json(raw)
+    except json.JSONDecodeError:
+        log("::warning::Model did not return valid JSON; posting raw output")
+        result = {"summary": raw, "verdict": "COMMENT", "comments": []}
+
+    summary = str(result.get("summary", "")).strip() or "_No summary provided._"
+    verdict = str(result.get("verdict", "COMMENT")).upper()
+    if verdict not in VERDICT_ICON:
+        verdict = "COMMENT"
+
+    # Validate inline comments against actual diff positions
+    line_index = {f.path: f.commentable_lines for f in kept}
+    inline: list[dict] = []
+    orphaned: list[str] = []
+    ponytail_count = 0
+    for c in result.get("comments", []) or []:
+        path = str(c.get("path", "")).lstrip("./")
+        body = str(c.get("body", "")).strip()
+        tag = str(c.get("tag", "") or "").lower().strip(": ")
+        if tag in PONYTAIL_TAGS:
+            ponytail_count += 1
+            rendered = f"✂️ **{tag}:** {body}"
+        else:
+            sev = str(c.get("severity", "medium")).lower()
+            rendered = f"{SEVERITY_ICON.get(sev, '🟠')} {body}"
+        try:
+            line = int(c.get("line"))
+        except (TypeError, ValueError):
+            line = -1
+        if not body:
+            continue
+        if path in line_index and line in line_index[path]:
+            inline.append({"path": path, "line": line, "side": "RIGHT", "body": rendered})
+        else:
+            orphaned.append(f"- `{path}`" + (f" (line {line})" if line > 0 else "") + f": {rendered}")
+
+    try:
+        net_lines = int(result.get("ponytail_net_lines", 0) or 0)
+    except (TypeError, ValueError):
+        net_lines = 0
+
+    # Build the review body
+    parts = [
+        REVIEW_MARKER,
+        f"## {VERDICT_ICON[verdict]} AI Review — {verdict.replace('_', ' ').title()}",
+        "",
+        summary,
+    ]
+    if orphaned:
+        parts += ["", "### Additional notes", *orphaned]
+    if ponytail_mode != "off":
+        if ponytail_count == 0 and net_lines == 0:
+            parts += ["", "**Ponytail:** Lean already. Ship."]
+        else:
+            parts += ["", f"**Ponytail:** {ponytail_count} thing(s) to cut · `net: {net_lines:+d} lines possible`"]
+    notes = []
+    if skipped_excluded:
+        notes.append(f"{len(skipped_excluded)} file(s) skipped by exclude patterns")
+    if skipped_size:
+        notes.append(f"{len(skipped_size)} file(s) skipped for size: " + ", ".join(f"`{p}`" for p in skipped_size))
+    if notes:
+        parts += ["", "<sub>" + " · ".join(notes) + "</sub>"]
+    footer = f"Model: `{model}` · Commit: `{head_sha[:7]}`"
+    if ponytail_mode != "off":
+        footer += f" · Ponytail `{ponytail_ref}` ({ponytail_mode})"
+    parts += ["", f"<sub>{footer}</sub>"]
+    body = "\n".join(parts)
+
+    # Post: try full review with inline comments, then without, then as a plain comment
+    if gh.create_review(pr_number, head_sha, body, inline):
+        log(f"Posted review with {len(inline)} inline comment(s)")
+        return 0
+    if inline:
+        log("Retrying review without inline comments")
+        fallback_body = body + "\n\n### Inline comments (could not be attached)\n" + "\n".join(
+            f"- `{c['path']}:{c['line']}` — {c['body']}" for c in inline
+        )
+        if gh.create_review(pr_number, head_sha, fallback_body, []):
+            return 0
+    gh.create_issue_comment(pr_number, body)
+    log("Posted review as an issue comment")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:  # surface as an annotation in the Actions UI
+        print(f"::error::{e}", file=sys.stderr)
+        sys.exit(1)

--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -33,6 +33,13 @@ Optional:
                         checkout (fetch-depth: 0). Ponytail loads as the native
                         OpenCode plugin instead of an inlined ruleset.
   AI_AGENT_TIMEOUT      Seconds allowed for the whole opencode run (default 1500).
+  AI_DRY_RUN            "true" runs everything but prints the review instead of
+                        posting it. Useful for reproducing a CI run locally:
+                          GITHUB_TOKEN=$(gh auth token) GITHUB_REPOSITORY=owner/repo \\
+                          PR_NUMBER=91 PR_HEAD_SHA=$(git rev-parse HEAD) \\
+                          AI_BACKEND=opencode AI_DRY_RUN=true AI_API_KEY=... \\
+                          AI_BASE_URL=... AI_MODEL=... AI_PONYTAIL=on \\
+                          python3 .github/scripts/ai_review.py
   AI_JSON_MODE          "true" (default) sends response_format=json_object. Set
                         "false" for reasoning models that stop dead under JSON
                         mode (Poolside Laguna does); the script auto-detects and
@@ -722,23 +729,126 @@ def call_opencode(
 
     cmd = [exe, "run", "--agent", "reviewer", "--model", f"review/{model}", task]
     log(f"Running: opencode run --agent reviewer --model review/{model} <task>")
-    try:
-        proc = subprocess.run(
-            cmd, cwd=repo_dir, env=env, capture_output=True, text=True, timeout=timeout,
-        )
-    except subprocess.TimeoutExpired as e:
-        raise RuntimeError(f"opencode timed out after {timeout}s") from e
 
-    if proc.stderr.strip():
-        tail = proc.stderr.strip().splitlines()[-30:]
-        log("opencode stderr (tail):\n  " + "\n  ".join(tail))
+    # Stream output as it arrives so the Actions log shows what the agent is doing,
+    # and we can tell "thinking" from "hung". stdout is kept for parsing; stderr is
+    # relayed live.
+    import selectors
+    proc = subprocess.Popen(
+        cmd, cwd=repo_dir, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, bufsize=1,
+    )
+    sel = selectors.DefaultSelector()
+    sel.register(proc.stdout, selectors.EVENT_READ, "out")
+    sel.register(proc.stderr, selectors.EVENT_READ, "err")
+    out_lines: list[str] = []
+    started = time.monotonic()
+    last_activity = started
+    last_heartbeat = started
+    open_streams = 2
+    warned_silent = False
+    while open_streams:
+        if time.monotonic() - started > timeout:
+            proc.kill()
+            tail = "".join(out_lines)[-2000:]
+            raise RuntimeError(
+                f"opencode timed out after {timeout}s. "
+                + (f"Last stdout:\n{tail}" if tail.strip() else "It produced no stdout at all; "
+                   "see the streamed stderr lines above for the last tool activity.")
+            )
+        if not warned_silent and not out_lines and time.monotonic() - started > 180:
+            log("::warning::No stdout from opencode after 3 minutes. Stderr lines above show tool activity; "
+                "if there are none, the agent may be blocked on plugin install or a permission prompt.")
+            warned_silent = True
+        remaining = timeout - (time.monotonic() - started)
+        for key, _ in sel.select(timeout=max(0.1, min(15, remaining))):
+            line = key.fileobj.readline()
+            if not line:
+                sel.unregister(key.fileobj)
+                open_streams -= 1
+                continue
+            last_activity = time.monotonic()
+            if key.data == "out":
+                out_lines.append(line)
+                log("  │ " + line.rstrip()[:300])
+            else:
+                log("  ┆ " + line.rstrip()[:300])
+        now = time.monotonic()
+        if now - last_heartbeat > 60:
+            idle = int(now - last_activity)
+            log(f"  ...agent running {int(now - started)}s, last output {idle}s ago")
+            last_heartbeat = now
+    proc.wait()
+
+    stdout = "".join(out_lines)
     if proc.returncode != 0:
-        raise RuntimeError(
-            f"opencode exited {proc.returncode}. stdout tail:\n{proc.stdout[-1500:]}"
-        )
-    if not proc.stdout.strip():
+        raise RuntimeError(f"opencode exited {proc.returncode}. stdout tail:\n{stdout[-1500:]}")
+    if not stdout.strip():
         raise RuntimeError("opencode produced no output")
-    return proc.stdout
+    return stdout
+
+
+
+PONYTAIL_LINE_RE = re.compile(r"^\s*(?:[-*]\s*)?L(\d+)\s*[:：]\s*(?:\*\*)?(\w+)(?:\*\*)?\s*[:：]?\s*(.+?)\s*$")
+NET_LINES_RE = re.compile(r"net\s*[:：]?\s*([-+]?\d+)\s*lines?", re.I)
+GENERIC_LINE_RE = re.compile(r"^\s*(?:[-*]\s*)?(?:`)?([\w./\-]+\.\w+)(?:`)?\s*[:：]\s*(?:L(?:ine)?\s*)?(\d+)\s*[:：\-–]\s*(.+?)\s*$")
+
+
+def parse_text_review(text: str, known_paths: list[str]) -> dict | None:
+    """Best-effort parse of a prose/Ponytail-format review into the JSON shape.
+    Recognises `L12: stdlib ...` lines under a file heading, `path:12: ...` lines,
+    and a `net: -N lines` footer. Returns None if nothing structured is found."""
+    text = re.sub(r"<think>.*?</think>", "", text, flags=re.S)
+    comments: list[dict] = []
+    current: str | None = None
+    net = 0
+    summary_lines: list[str] = []
+    by_basename = {os.path.basename(p): p for p in known_paths}
+
+    for raw in text.splitlines():
+        line = raw.strip().strip("`").strip()
+        # File heading: a known path (or its basename) on its own line, possibly with ## or **
+        bare = line.lstrip("#").strip().strip("*").strip().strip(":")
+        if bare in known_paths:
+            current = bare
+            continue
+        if bare in by_basename:
+            current = by_basename[bare]
+            continue
+        m = PONYTAIL_LINE_RE.match(raw)
+        if m and current:
+            tag = m.group(2).lower()
+            body = m.group(3)
+            c = {"path": current, "line": int(m.group(1)), "body": body}
+            if tag in PONYTAIL_TAGS:
+                c["tag"] = tag
+            else:
+                c["body"] = f"{m.group(2)} {body}".strip()
+                c["severity"] = "medium"
+            comments.append(c)
+            continue
+        m = GENERIC_LINE_RE.match(raw)
+        if m and (m.group(1) in known_paths or m.group(1) in by_basename):
+            path = m.group(1) if m.group(1) in known_paths else by_basename[m.group(1)]
+            comments.append({"path": path, "line": int(m.group(2)), "body": m.group(3), "severity": "medium"})
+            continue
+        nm = NET_LINES_RE.search(raw)
+        if nm:
+            net = int(nm.group(1))
+            continue
+        if line:
+            summary_lines.append(raw.rstrip())
+
+    if not comments and net == 0:
+        return None
+    summary = "\n".join(summary_lines).strip()
+    if len(summary) > 1500:
+        summary = summary[:1500] + "\n\n_…truncated_"
+    return {
+        "summary": summary or "_Review returned as a findings list; see comments._",
+        "verdict": "COMMENT",
+        "comments": comments,
+        "ponytail_net_lines": net,
+    }
 
 
 def extract_json(text: str) -> dict:
@@ -793,6 +903,7 @@ def main() -> int:
         log(f"::warning::Unknown AI_BACKEND {backend!r}; using 'api'")
         backend = "api"
     repo_dir = env("GITHUB_WORKSPACE", os.getcwd())
+    dry_run = env("AI_DRY_RUN", "false").strip().lower() in ("true", "1", "yes")
     agent_timeout = int(env("AI_AGENT_TIMEOUT", "1500"))
     extra_body: dict = {}
     if env("AI_EXTRA_BODY"):
@@ -864,7 +975,11 @@ def main() -> int:
         task = (
             pr_header
             + f"Changed files ({len(kept)}): " + ", ".join(f.path for f in kept) + "\n\n"
-            + f"Review this pull request. Start with `git diff origin/{base_ref}...HEAD`."
+            + f"Review this pull request. Start with `git diff origin/{base_ref}...HEAD`.\n\n"
+            + "FORMAT: your final message must be exactly one JSON object with keys summary, verdict, comments"
+            + (", ponytail_net_lines" if ponytail_mode != "off" else "")
+            + ". Put Ponytail findings inside comments with a tag field; do not use the L<line>: text format. "
+              "No prose before or after the JSON."
         )
         cfg_dir = os.path.join(env("RUNNER_TEMP", "/tmp"), "ai-review-opencode")
         cfg_path = write_opencode_config(
@@ -887,6 +1002,14 @@ def main() -> int:
     except json.JSONDecodeError:
         log("::warning::Model did not return valid JSON. First 1500 chars of output:")
         log(raw[:1500])
+        result = parse_text_review(raw, [f.path for f in kept])
+        if result:
+            log(f"Parsed the text as a findings list: {len(result['comments'])} comment(s)")
+    if not result and raw.strip() and len(raw.strip()) > 80 and "{" not in raw:
+        # Plain prose review with no structure: post it as the summary rather than an error
+        log("Model replied in prose; posting it as the summary")
+        result = {"summary": raw.strip()[:4000], "verdict": "COMMENT", "comments": []}
+    if not result:
         result = {
             "summary": (
                 "_The model returned output that could not be parsed as a review. "
@@ -936,16 +1059,30 @@ def main() -> int:
     except (TypeError, ValueError):
         net_lines = 0
 
+    total = len(result.get("comments", []) or [])
+    log(
+        f"Model returned {total} comment(s): {len(inline)} anchored to diff lines, "
+        f"{len(orphaned)} unanchored (moved to notes), {ponytail_count} Ponytail-tagged; "
+        f"verdict={verdict}, ponytail_net_lines={net_lines}"
+    )
+    for o in orphaned[:10]:
+        log("  unanchored: " + o[:200])
+
     # Build the review body
+    if ponytail_mode == "only":
+        heading = "## ✂️ Ponytail Review — " + ("Lean already. Ship." if ponytail_count == 0 and net_lines == 0
+                                                 else f"`net: {net_lines:+d} lines possible`")
+    else:
+        heading = f"## {VERDICT_ICON[verdict]} AI Review — {verdict.replace('_', ' ').title()}"
     parts = [
-        REVIEW_MARKER,
-        f"## {VERDICT_ICON[verdict]} AI Review — {verdict.replace('_', ' ').title()}",
+        REVIEW_MARKER.replace("-->", f" {ponytail_mode} -->"),
+        heading,
         "",
         summary,
     ]
     if orphaned:
         parts += ["", "### Additional notes", *orphaned]
-    if ponytail_mode != "off":
+    if ponytail_mode == "on":
         if ponytail_count == 0 and net_lines == 0:
             parts += ["", "**Ponytail:** Lean already. Ship."]
         else:
@@ -962,6 +1099,13 @@ def main() -> int:
         footer += f" · Ponytail `{ponytail_ref}` ({ponytail_mode})"
     parts += ["", f"<sub>{footer}</sub>"]
     body = "\n".join(parts)
+
+    if dry_run:
+        log("\n===== DRY RUN: review body =====\n" + body)
+        log(f"\n===== {len(inline)} inline comment(s) =====")
+        for c in inline:
+            log(f"{c['path']}:{c['line']}  {c['body'][:200]}")
+        return 0
 
     # Post: try full review with inline comments, then without, then as a plain comment
     if gh.create_review(pr_number, head_sha, body, inline):

--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -494,57 +494,77 @@ def call_model(
     if extra_body:
         payload.update(extra_body)  # provider-specific knobs, e.g. chat_template_kwargs
 
-    reply: ModelReply | None = None
-    transport_failures = 0
-    for _ in range(8):  # bounded: at most a few param adaptations + 2 transport retries
-        try:
-            reply = _post_chat(url, headers, payload, timeout)
-            break
-        except ProviderError as e:
-            err = e.body.lower()
-            if e.status == 400 and "response_format" in err and "response_format" in payload:
-                log("Provider rejected response_format; retrying without JSON mode")
-                payload.pop("response_format")
-            elif e.status == 400 and "stream_options" in err and "stream_options" in payload:
-                log("Provider rejected stream_options; retrying without it")
-                payload.pop("stream_options")
-            elif e.status == 400 and "stream" in err and payload.get("stream"):
-                log("Provider rejected streaming; retrying non-streaming")
-                payload.pop("stream", None)
-                payload.pop("stream_options", None)
-            elif e.status == 400 and "max_completion_tokens" in err and "max_tokens" in payload:
-                log("Provider wants max_completion_tokens; retrying")
-                payload["max_completion_tokens"] = payload.pop("max_tokens")
-            elif e.status == 400 and "temperature" in err and "temperature" in payload:
-                log("Provider rejected temperature; retrying without it")
-                payload.pop("temperature")
-            elif e.status in (429, 500, 502, 503, 504) and transport_failures < 2:
+    def request(payload: dict) -> ModelReply:
+        transport_failures = 0
+        for _ in range(8):  # bounded: a few param adaptations + 2 transport retries
+            try:
+                return _post_chat(url, headers, payload, timeout)
+            except ProviderError as e:
+                err = e.body.lower()
+                if e.status == 400 and "response_format" in err and "response_format" in payload:
+                    log("Provider rejected response_format; retrying without JSON mode")
+                    payload.pop("response_format")
+                elif e.status == 400 and "stream_options" in err and "stream_options" in payload:
+                    log("Provider rejected stream_options; retrying without it")
+                    payload.pop("stream_options")
+                elif e.status == 400 and "stream" in err and payload.get("stream"):
+                    log("Provider rejected streaming; retrying non-streaming")
+                    payload.pop("stream", None)
+                    payload.pop("stream_options", None)
+                elif e.status == 400 and "max_completion_tokens" in err and "max_tokens" in payload:
+                    log("Provider wants max_completion_tokens; retrying")
+                    payload["max_completion_tokens"] = payload.pop("max_tokens")
+                elif e.status == 400 and "temperature" in err and "temperature" in payload:
+                    log("Provider rejected temperature; retrying without it")
+                    payload.pop("temperature")
+                elif e.status in (429, 500, 502, 503, 504) and transport_failures < 2:
+                    transport_failures += 1
+                    log(f"HTTP {e.status} from provider (retry {transport_failures}/2): {e.body[:200]}")
+                    time.sleep(5 * transport_failures)
+                else:
+                    raise RuntimeError(f"Model request failed ({e.status}): {e.body[:800]}") from None
+            except RETRYABLE as e:
                 transport_failures += 1
-                log(f"HTTP {e.status} from provider (retry {transport_failures}/2): {e.body[:200]}")
+                if transport_failures > 2:
+                    raise RuntimeError(f"Model request failed after retries: {e!r}") from None
+                log(f"Transport error (retry {transport_failures}/2): {e!r}")
                 time.sleep(5 * transport_failures)
-            else:
-                raise RuntimeError(f"Model request failed ({e.status}): {e.body[:800]}") from None
-        except RETRYABLE as e:
-            transport_failures += 1
-            if transport_failures > 2:
-                raise RuntimeError(f"Model request failed after retries: {e!r}") from None
-            log(f"Transport error (retry {transport_failures}/2): {e!r}")
-            time.sleep(5 * transport_failures)
-    if reply is None:
         raise RuntimeError("Model request failed: too many parameter adaptations")
 
-    if reply.usage:
-        log(f"Usage: {json.dumps(reply.usage)}")
-    if reply.finish_reason == "length":
-        log(
-            "::warning::Response was cut off at max_tokens. Reasoning models spend tokens "
-            "thinking before answering; raise AI_MAX_TOKENS or lower AI_MAX_DIFF_CHARS."
-        )
+    def report(reply: ModelReply) -> None:
+        if reply.usage:
+            log(f"Usage: {json.dumps(reply.usage)}")
+        log(f"finish_reason={reply.finish_reason!r}, content={len(reply.content)} chars, reasoning={len(reply.reasoning)} chars")
+        if reply.finish_reason == "length":
+            log(
+                "::warning::Response was cut off at max_tokens. Reasoning models spend tokens "
+                "thinking before answering; raise AI_MAX_TOKENS or lower AI_MAX_DIFF_CHARS."
+            )
+
+    reply = request(payload)
+    report(reply)
+
+    # Reasoning models on some stacks stop dead when JSON mode is on: they think,
+    # then emit nothing. Retry once without response_format if that's what we see.
+    if not reply.content.strip() and reply.reasoning.strip() and "response_format" in payload \
+            and reply.finish_reason != "length":
+        log("::warning::Model reasoned but produced no content with JSON mode on; retrying without response_format")
+        payload.pop("response_format")
+        reply = request(payload)
+        report(reply)
 
     content = reply.content
     if not content.strip() and reply.reasoning.strip():
-        log("::warning::content was empty; falling back to reasoning text")
-        content = reply.reasoning
+        # Last resort: some models put the final JSON inside the reasoning channel
+        try:
+            extract_json(reply.reasoning)
+            log("::warning::content was empty but reasoning contains a review object; using it")
+            content = reply.reasoning
+        except json.JSONDecodeError:
+            raise RuntimeError(
+                f"Model reasoned ({len(reply.reasoning)} chars) but returned no answer "
+                f"(finish_reason={reply.finish_reason!r}). Start of reasoning:\n{reply.reasoning[:600]}"
+            ) from None
     if not content.strip():
         raise RuntimeError(
             f"Model returned no content (finish_reason={reply.finish_reason!r}). "

--- a/.github/workflows/auto-pr-review.yml
+++ b/.github/workflows/auto-pr-review.yml
@@ -1,5 +1,10 @@
 name: AI PR Review
 
+# Deliberately `pull_request`, not `pull_request_target`: fork PRs then get no
+# secrets and a read-only token, so untrusted code can never run next to
+# AI_API_KEY. The fork guard below skips them cleanly instead of failing.
+# (`pull_request_target` would instead run privileged against fork PRs, which
+# is exactly the combination the opencode backend must never see.)
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -10,7 +15,11 @@ permissions:
 
 jobs:
   review:
-    if: github.event.pull_request.draft == false
+    # Same-repo, non-draft PRs only: fork PRs have no access to AI_API_KEY,
+    # so running the job for them could only ever end in a red X.
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -45,16 +54,21 @@ jobs:
 
     steps:
       # --- Checkout -------------------------------------------------------
-      - uses: actions/checkout@v7
+      # Pinned to a full commit SHA so an upstream tag move cannot change the
+      # code this workflow runs. persist-credentials: false keeps GITHUB_TOKEN
+      # out of .git/config (the repo is public; later fetches work anonymously).
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: env.RUN_THIS_PASS == 'true' && env.AI_BACKEND != 'opencode'
         with:
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
+          persist-credentials: false
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: env.RUN_THIS_PASS == 'true' && env.AI_BACKEND == 'opencode'
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Fetch base branch for diffing
         if: env.RUN_THIS_PASS == 'true' && env.AI_BACKEND == 'opencode'

--- a/.github/workflows/auto-pr-review.yml
+++ b/.github/workflows/auto-pr-review.yml
@@ -41,7 +41,8 @@ jobs:
           AI_MAX_DIFF_CHARS: ${{ vars.AI_MAX_DIFF_CHARS }}     # default 120000
           AI_TEMPERATURE: ${{ vars.AI_TEMPERATURE }}           # default 0.2
           AI_MAX_TOKENS: ${{ vars.AI_MAX_TOKENS }}             # default 8000; raise for reasoning models
-          AI_TIMEOUT: ${{ vars.AI_TIMEOUT }}                   # seconds, default 600
+          AI_TIMEOUT: ${{ vars.AI_TIMEOUT }}                   # per-chunk read timeout, default 600
+          AI_STREAM: ${{ vars.AI_STREAM }}                     # default true; keeps long requests alive
           # Provider-specific request fields as a JSON object, e.g. to disable thinking:
           #   Poolside/vLLM: {"chat_template_kwargs": {"enable_thinking": false}}
           #   OpenRouter:    {"reasoning": {"effort": "low"}}

--- a/.github/workflows/auto-pr-review.yml
+++ b/.github/workflows/auto-pr-review.yml
@@ -1,0 +1,59 @@
+name: AI PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+# Prevent overlapping reviews on rapid pushes to the same PR
+concurrency:
+  group: ai-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    # Skip drafts, and skip if the required secret isn't configured
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      # No setup-python: the script is stdlib-only (Python >= 3.9) and
+      # ubuntu-latest ships a current Python 3 already.
+      - name: Run AI review
+        env:
+          # --- Provider configuration ---------------------------------------
+          # Secrets  -> Settings > Secrets and variables > Actions > Secrets
+          # Variables-> Settings > Secrets and variables > Actions > Variables
+          AI_API_KEY: ${{ secrets.AI_API_KEY }}
+          AI_BASE_URL: ${{ vars.AI_BASE_URL }}       # e.g. https://api.openai.com/v1
+          AI_MODEL: ${{ vars.AI_MODEL }}             # e.g. gpt-4o-mini
+
+          # --- Optional tuning (all have sensible defaults) -----------------
+          AI_MAX_DIFF_CHARS: ${{ vars.AI_MAX_DIFF_CHARS }}     # default 120000
+          AI_TEMPERATURE: ${{ vars.AI_TEMPERATURE }}           # default 0.2
+          AI_MAX_TOKENS: ${{ vars.AI_MAX_TOKENS }}             # default 4000
+          AI_EXCLUDE_PATTERNS: ${{ vars.AI_EXCLUDE_PATTERNS }} # comma-separated globs
+          AI_EXTRA_INSTRUCTIONS: ${{ vars.AI_EXTRA_INSTRUCTIONS }}
+
+          # --- Ponytail (over-engineering review) --------------------------
+          # off  = standard correctness/security review (default)
+          # on   = standard review + Ponytail delete-list in the same pass
+          # only = Ponytail pass alone; no correctness/security findings
+          AI_PONYTAIL: ${{ vars.AI_PONYTAIL }}
+          AI_PONYTAIL_REF: ${{ vars.AI_PONYTAIL_REF }}          # default: pinned release tag
+
+          # --- GitHub context (automatic) ----------------------------------
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python3 .github/scripts/ai_review.py

--- a/.github/workflows/auto-pr-review.yml
+++ b/.github/workflows/auto-pr-review.yml
@@ -15,19 +15,45 @@ permissions:
 
 jobs:
   review:
-    # Skip drafts, and skip if the required secret isn't configured
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
+    env:
+      # "api" (default): post the diff to /chat/completions directly.
+      # "opencode": run a read-only OpenCode agent inside the checkout.
+      AI_BACKEND: ${{ vars.AI_BACKEND || 'api' }}
+
     steps:
+      # --- Checkout -------------------------------------------------------
+      # The API backend only needs the script. The OpenCode backend needs the
+      # whole repo so the agent can read around the diff.
       - uses: actions/checkout@v7
+        if: env.AI_BACKEND != 'opencode'
         with:
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
 
-      # No setup-python: the script is stdlib-only (Python >= 3.9) and
-      # ubuntu-latest ships a current Python 3 already.
+      - uses: actions/checkout@v7
+        if: env.AI_BACKEND == 'opencode'
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch for diffing
+        if: env.AI_BACKEND == 'opencode'
+        run: git fetch --no-tags origin "${{ github.event.pull_request.base.ref }}"
+
+      # --- OpenCode install (opencode backend only) ------------------------
+      - name: Install OpenCode
+        if: env.AI_BACKEND == 'opencode'
+        run: |
+          curl -fsSL https://opencode.ai/install | bash
+          echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
+      - name: Verify OpenCode
+        if: env.AI_BACKEND == 'opencode'
+        run: opencode --version
+
+      # --- Review ----------------------------------------------------------
       - name: Run AI review
         env:
           # --- Provider configuration ---------------------------------------
@@ -41,8 +67,10 @@ jobs:
           AI_MAX_DIFF_CHARS: ${{ vars.AI_MAX_DIFF_CHARS }}     # default 120000
           AI_TEMPERATURE: ${{ vars.AI_TEMPERATURE }}           # default 0.2
           AI_MAX_TOKENS: ${{ vars.AI_MAX_TOKENS }}             # default 8000; raise for reasoning models
-          AI_TIMEOUT: ${{ vars.AI_TIMEOUT }}                   # per-chunk read timeout, default 600
-          AI_STREAM: ${{ vars.AI_STREAM }}                     # default true; keeps long requests alive
+          AI_TIMEOUT: ${{ vars.AI_TIMEOUT }}                   # api: per-chunk read timeout, default 600
+          AI_AGENT_TIMEOUT: ${{ vars.AI_AGENT_TIMEOUT }}       # opencode: whole run, default 1500
+          AI_STREAM: ${{ vars.AI_STREAM }}                     # api: default true
+          AI_JSON_MODE: ${{ vars.AI_JSON_MODE }}               # api: set false for reasoning models
           # Provider-specific request fields as a JSON object, e.g. to disable thinking:
           #   Poolside/vLLM: {"chat_template_kwargs": {"enable_thinking": false}}
           #   OpenRouter:    {"reasoning": {"effort": "low"}}
@@ -54,6 +82,8 @@ jobs:
           # off  = standard correctness/security review (default)
           # on   = standard review + Ponytail delete-list in the same pass
           # only = Ponytail pass alone; no correctness/security findings
+          # api backend inlines the ruleset from AI_PONYTAIL_REF; opencode
+          # backend loads the native @dietrichgebert/ponytail plugin instead.
           AI_PONYTAIL: ${{ vars.AI_PONYTAIL }}
           AI_PONYTAIL_REF: ${{ vars.AI_PONYTAIL_REF }}          # default: pinned release tag
 

--- a/.github/workflows/auto-pr-review.yml
+++ b/.github/workflows/auto-pr-review.yml
@@ -18,7 +18,7 @@ jobs:
     # Skip drafts, and skip if the required secret isn't configured
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v7
@@ -40,7 +40,12 @@ jobs:
           # --- Optional tuning (all have sensible defaults) -----------------
           AI_MAX_DIFF_CHARS: ${{ vars.AI_MAX_DIFF_CHARS }}     # default 120000
           AI_TEMPERATURE: ${{ vars.AI_TEMPERATURE }}           # default 0.2
-          AI_MAX_TOKENS: ${{ vars.AI_MAX_TOKENS }}             # default 4000
+          AI_MAX_TOKENS: ${{ vars.AI_MAX_TOKENS }}             # default 8000; raise for reasoning models
+          AI_TIMEOUT: ${{ vars.AI_TIMEOUT }}                   # seconds, default 600
+          # Provider-specific request fields as a JSON object, e.g. to disable thinking:
+          #   Poolside/vLLM: {"chat_template_kwargs": {"enable_thinking": false}}
+          #   OpenRouter:    {"reasoning": {"effort": "low"}}
+          AI_EXTRA_BODY: ${{ vars.AI_EXTRA_BODY }}
           AI_EXCLUDE_PATTERNS: ${{ vars.AI_EXCLUDE_PATTERNS }} # comma-separated globs
           AI_EXTRA_INSTRUCTIONS: ${{ vars.AI_EXTRA_INSTRUCTIONS }}
 

--- a/.github/workflows/auto-pr-review.yml
+++ b/.github/workflows/auto-pr-review.yml
@@ -4,11 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
-# Prevent overlapping reviews on rapid pushes to the same PR
-concurrency:
-  group: ai-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   pull-requests: write
@@ -19,51 +14,71 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Pass 1: correctness / security review from the diff.
+          - pass: review
+            ponytail: "off"
+            backend: ${{ vars.AI_BACKEND || 'api' }}
+            model: ${{ vars.AI_MODEL }}
+            base_url: ${{ vars.AI_BASE_URL }}
+          # Pass 2: Ponytail over-engineering review. Defaults to the same
+          # endpoint/model but can be pointed at a cheaper or faster one, and
+          # to the opencode backend so it can read the codebase.
+          - pass: ponytail
+            ponytail: "only"
+            backend: ${{ vars.AI_PONYTAIL_BACKEND || vars.AI_BACKEND || 'api' }}
+            model: ${{ vars.AI_PONYTAIL_MODEL || vars.AI_MODEL }}
+            base_url: ${{ vars.AI_PONYTAIL_BASE_URL || vars.AI_BASE_URL }}
+
+    # One in-flight run per PR per pass; a new push cancels the stale one.
+    concurrency:
+      group: ai-review-${{ matrix.pass }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+
+    # Set AI_PASSES to "review" or "ponytail" to run only one of them.
     env:
-      # "api" (default): post the diff to /chat/completions directly.
-      # "opencode": run a read-only OpenCode agent inside the checkout.
-      AI_BACKEND: ${{ vars.AI_BACKEND || 'api' }}
+      AI_BACKEND: ${{ matrix.backend }}
+      RUN_THIS_PASS: ${{ !vars.AI_PASSES || contains(vars.AI_PASSES, matrix.pass) }}
 
     steps:
       # --- Checkout -------------------------------------------------------
-      # The API backend only needs the script. The OpenCode backend needs the
-      # whole repo so the agent can read around the diff.
       - uses: actions/checkout@v7
-        if: env.AI_BACKEND != 'opencode'
+        if: env.RUN_THIS_PASS == 'true' && env.AI_BACKEND != 'opencode'
         with:
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
 
       - uses: actions/checkout@v7
-        if: env.AI_BACKEND == 'opencode'
+        if: env.RUN_THIS_PASS == 'true' && env.AI_BACKEND == 'opencode'
         with:
           fetch-depth: 0
 
       - name: Fetch base branch for diffing
-        if: env.AI_BACKEND == 'opencode'
+        if: env.RUN_THIS_PASS == 'true' && env.AI_BACKEND == 'opencode'
         run: git fetch --no-tags origin "${{ github.event.pull_request.base.ref }}"
 
       # --- OpenCode install (opencode backend only) ------------------------
       - name: Install OpenCode
-        if: env.AI_BACKEND == 'opencode'
+        if: env.RUN_THIS_PASS == 'true' && env.AI_BACKEND == 'opencode'
         run: |
           curl -fsSL https://opencode.ai/install | bash
           echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
-      - name: Verify OpenCode
-        if: env.AI_BACKEND == 'opencode'
-        run: opencode --version
 
       # --- Review ----------------------------------------------------------
-      - name: Run AI review
+      - name: Run ${{ matrix.pass }} pass
+        if: env.RUN_THIS_PASS == 'true'
         env:
-          # --- Provider configuration ---------------------------------------
-          # Secrets  -> Settings > Secrets and variables > Actions > Secrets
-          # Variables-> Settings > Secrets and variables > Actions > Variables
-          AI_API_KEY: ${{ secrets.AI_API_KEY }}
-          AI_BASE_URL: ${{ vars.AI_BASE_URL }}       # e.g. https://api.openai.com/v1
-          AI_MODEL: ${{ vars.AI_MODEL }}             # e.g. gpt-4o-mini
+          # --- Provider (per pass; see matrix above) -------------------------
+          AI_API_KEY: ${{ matrix.pass == 'ponytail' && secrets.AI_PONYTAIL_API_KEY || secrets.AI_API_KEY }}
+          AI_BASE_URL: ${{ matrix.base_url }}
+          AI_MODEL: ${{ matrix.model }}
+          AI_PONYTAIL: ${{ matrix.ponytail }}
+          AI_PONYTAIL_REF: ${{ vars.AI_PONYTAIL_REF }}
 
-          # --- Optional tuning (all have sensible defaults) -----------------
+          # --- Optional tuning (shared by both passes) -----------------------
           AI_MAX_DIFF_CHARS: ${{ vars.AI_MAX_DIFF_CHARS }}     # default 120000
           AI_TEMPERATURE: ${{ vars.AI_TEMPERATURE }}           # default 0.2
           AI_MAX_TOKENS: ${{ vars.AI_MAX_TOKENS }}             # default 8000; raise for reasoning models
@@ -77,15 +92,6 @@ jobs:
           AI_EXTRA_BODY: ${{ vars.AI_EXTRA_BODY }}
           AI_EXCLUDE_PATTERNS: ${{ vars.AI_EXCLUDE_PATTERNS }} # comma-separated globs
           AI_EXTRA_INSTRUCTIONS: ${{ vars.AI_EXTRA_INSTRUCTIONS }}
-
-          # --- Ponytail (over-engineering review) --------------------------
-          # off  = standard correctness/security review (default)
-          # on   = standard review + Ponytail delete-list in the same pass
-          # only = Ponytail pass alone; no correctness/security findings
-          # api backend inlines the ruleset from AI_PONYTAIL_REF; opencode
-          # backend loads the native @dietrichgebert/ponytail plugin instead.
-          AI_PONYTAIL: ${{ vars.AI_PONYTAIL }}
-          AI_PONYTAIL_REF: ${{ vars.AI_PONYTAIL_REF }}          # default: pinned release tag
 
           # --- GitHub context (automatic) ----------------------------------
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds an AI-powered automatic PR review agent:

- **`.github/workflows/auto-pr-review.yml`** — triggers on `opened`/`synchronize`/`reopened`/`ready_for_review`. Per-PR concurrency guard cancels stale runs on rapid pushes; least-privilege permissions (`contents: read`, `pull-requests: write`); skips drafts; sparse-checkouts only `.github/scripts`; no `setup-python` needed (script is stdlib-only, Python ≥ 3.9).
- **`.github/scripts/ai_review.py`** — stdlib-only reviewer that works with any OpenAI-compatible chat-completions endpoint. Fetches the PR diff, filters files by exclude patterns and a size budget, calls the model with a correctness/security-focused prompt, validates inline comment positions against the actual diff (preventing GitHub 422s), and posts the review with a graceful fallback chain: full review → review without inline comments → plain issue comment.

Optional **Ponytail mode** (`AI_PONYTAIL=on|only`) adds an over-engineering review pass using the ruleset from DietrichGebert/ponytail, pinned to a tag so upstream edits can't silently change behavior.

## Setup required after merge

1. Add secret: **`AI_API_KEY`**
2. Add variables: **`AI_BASE_URL`** (e.g. `https://api.openai.com/v1`) and **`AI_MODEL`** (e.g. `gpt-4o-mini`)
3. Optional tuning variables are documented inline in the workflow (`AI_MAX_DIFF_CHARS`, `AI_TEMPERATURE`, `AI_MAX_TOKENS`, `AI_EXCLUDE_PATTERNS`, `AI_EXTRA_INSTRUCTIONS`, `AI_PONYTAIL`, `AI_PONYTAIL_REF`).

Without the secret configured the workflow runs but exits with a clear error — it will not post anything.

## Notes

- Reviews always post as `COMMENT` events (never `APPROVE`/`REQUEST_CHANGES`), keeping them advisory.
- `.phpactor.json` (editor LSP config) is intentionally left out of this PR as unrelated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated AI-powered reviews for eligible, non-draft pull requests.
  * Reviews can provide inline feedback on changed lines or general comments when inline placement is unavailable.
  * Added support for selectable API and agent-based review backends.
  * Added configurable providers, models, instructions, token limits, streaming, and specialized review rules.
* **Bug Fixes**
  * Improved handling of timeouts, retries, incomplete responses, and invalid review output.
  * Added clearer diagnostics when automated reviews cannot be posted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->